### PR TITLE
ITE-4: Add generic URI schemes for artifacts in in-toto metadata

### DIFF
--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -504,8 +504,8 @@ abstract resources securely. It is quite possible that the contents of these
 resources need to be serialized in some manner that allows for their hashing,
 and these operations when performed unsafely can lead to severe vulnerabilities
 if the resource is controlled by a malicious actor. Implementors must also take
-care to ensure they handle situations where a resource may be unavailable, and
-fail appropriately.
+care to ensure ITE-4 compliant systems are capable of handling situations where
+an abstract resource is unavailable, and fail appropriately.
 
 NOTE: There is an ongoing discussion about limiting the scope of this ITE to
 static or unchanging resources. Thread: https://github.com/in-toto/ITE/issues/7

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -188,7 +188,7 @@ GitHub has more abstract entities such as Pull Requests and Issues. These
 entities can be referred to directly using the URI schemes proposed in this ITE
 and help provide attestations about these artifacts. Consider:
 
-===== Attestations for merging a pull request into `master`
+===== in-toto link attestations for merging a pull request into `master`
 
 A pull request is a proposal to make changes to a repository. Changes are either
 made on a separate branch on the same repository or a branch on a fork of the
@@ -228,7 +228,7 @@ commit. The attestation could look something like:
 This step is accepting the pull request as a material and is recording the merge
 commit as a product.
 
-===== Attestations for GitHub Actions building from a merge commit
+===== in-toto link attesations for GitHub Actions building from a merge commit
 
 GitHub Actions can be used to set up a workflow for continuous integration (CI).
 Workflows can be triggered on push and an attestation can be generated for the

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -182,6 +182,38 @@ a software package in detail. They're composed of several entities that have
 unique identifiers. These identifiers can be used in in-toto metadata embedded
 in SPDX documents to refer to the respective entities.
 
+===== in-toto link attestation for packaging SPDX files into an SPDX package
+
+An in-toto attestation can be bundled into an SPDX document to show the chain of
+custody for the elements the SPDX document refers to. Here, we see how
+provenance can be attested to for File and Package entities in an SPDX document.
+
+```
+{
+    "_type": "link",
+    "name": "package-ghostscript-9.21.tar.gz",
+    "command": "<COMMAND>",
+    "materials": {
+        "spdx:SPDXRef-141-File-83pv-RKSJ-H-d51620a4d7d9aeca3a1cbe5ef201513f98d65f98": <HASH>,
+        "spdx:SPDXRef-271-File-AUTHORS.md-109c93392646b4d55e3ca62c5b578a9ac7cc159f": <HASH>,
+        "...": "..."
+    },
+    "products": {
+        "spdx:SPDXRef-Pkg-ghostscript-9.21.tar.gz-6f60d7fcb5eef6a8bec5abedf21c6a7008a8c0c7": <HASH>
+    },
+    "byproducts": {
+        "stderr": "",
+        "stdout": "",
+        "return-value": ""
+    },
+    "environment": {
+        "variables": "",
+        "filesystem": "",
+        "workdir": ""
+    }
+}
+```
+
 ==== Use Case 2: GitHub Entities
 
 GitHub has more abstract entities such as Pull Requests and Issues. These

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -205,13 +205,19 @@ enables them to be reused by different stakeholders looking to hash the same
 abstract entities.
 
 ```
-define hash_artifacts(string generic_uri, list hash_algorithms, kwargs) \
-    returns map artifact_hash_map
+function hash_artifacts(string generic_uri, list hash_algorithms, kwargs) \
+        returns map artifact_hash_map
+    contained_uris <- resolve_uri(generic_uri)
+    for each uri in contained_uris do
+        hashable_representation <- get_hashable_representation
+        set artifact_hash_map[uri] <- hash(hashable_representation)
 
-define resolve_uri(string generic_uri, kwargs) returns list contained_uris
 
-define get_hashable_representation(string generic_uri, kwargs) returns bytes \
-    hashable_representation
+function resolve_uri(string generic_uri, kwargs) returns list contained_uris
+
+
+function get_hashable_representation(string generic_uri, kwargs) returns bytes \
+        hashable_representation
 ```
 
 `hash_artifacts` closely mirrors the general workflow of hashing artifacts in
@@ -240,9 +246,16 @@ It is quite likely that a generic URI specified may point to a collection of
 abstract entities. In the present framework where all artifacts are part of the
 filesystem, this is akin to using the path of a directory to record all the
 contents of the directory as the actual artifacts of the step. Therefore,
-`resolve_uri` is used to resolve such URIs to multiple different artifacts that
-they contain. Each of them must be hashed using their corresponding hashable
-representations.
+in these instances, a method `resolve_uri` must be used to resolve the
+collective URI into the URIs of many different artifacts that are contained or
+represented by the collective URI. Each of them must be hashed using their
+corresponding hashable representations.
+
+Such a method is optional and the operations performed to unpack collective URIs
+into individual URIs need not be implemented if the context or type or abstract
+resources do not require them. All the methods defined above can contain
+additional arguments that may be used to control these and other options of
+operation.
 
 [[motivation]]
 == Motivation

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -379,17 +379,48 @@ information for.
 [[security]]
 == Security
 
-It's important to note that file paths are a form of URIs too, and can be
-represented with the `scheme` `file://`. We have also discovered that `MATCH`
-and other artifact rules use only the URI strings themselves to find the
-appropriate entries in the link metadata. The changes proposed in this ITE,
-therefore, have no effect on the security guarantees made by the in-toto
-specification.
+As per the in-toto specification, the only direct interaction in-toto tools have
+with artifacts is to record their hashes using one or more cryptographic hash
+algorithms. Other artifact operations such as verifying the artifact rules
+rely on the hashes recorded in the link metadata.
 
-Implementing systems that conform to this ITE must, however, be careful with how
-they compute cryptographic hashes of abstract entities. The implementors must
-understand the abstract entities they are hashing so as to be able to do so
-consistently.
+We found that the extending the recording of hashes to abstract resources, some
+of which may live at remote locations, is more complicated than the recording of
+hashes of artifacts in the local filesystem. It is, therefore, important for
+ITE-4 compliant in-toto tools to handle the resolving of generic URIs to these
+abstract resources securely. It is quite possible that the contents of these
+resources need to be serialized in some manner that allows for their hashing,
+and these operations when performed unsafely can lead to severe vulnerabilities
+if the resource is controlled by a malicious actor.
+
+Further, it is likely that abstract resources change more frequently, both in
+content and format, and implementors must take care to identify how these
+contents are recorded, as well what specific information is recorded for a
+particular type of entity. Otherwise, the in-toto verification workflow can be
+plagued by failures due to the lack of availability of the artifact as
+previously recorded. For example, implementors who decide how to resolve GitHub
+pull request must decide what information encoded in a pull request must be
+hashed. If they are considering the comments of various users when hashing the
+pull request, this can lead to differences in the hashes recorded by different
+steps in the supply chain even if the changes proposed in the pull request are
+the same. This will of course eventually lead to a failure of the in-toto
+verification workflow.
+
+As always, it is also necessary to consider the actors who can make changes to
+an abstract entity. This is perhaps slightly exacerbated in the case of abstract
+resources as the content and format being hashed aren't as specific as artifacts
+in the local filesystem. In the above example, for a public repository, *any*
+GitHub user can comment on a pull request, so for an implementation that also
+considers comments when recording the hash, any user can potentially cause a
+failure of the verification workflow. This can potentially be leveraged by a
+malicious actor to target automated pipelines that rely on in-toto verification.
+
+Finally, our analysis showed that verification of artifact rules specified in
+in-toto layouts use the hashes recorded while generating the link metadata and
+do not record afresh any of the hashes. So the security properties of artifact
+rules verification rely on the above points - ensuring the hashes are recorded
+correctly for a given context. The change in the URI format has no direct impact
+on the artifact rules and their verification.
 
 [[infrastructure-requirements]]
 == Infrastructure Requirements

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -146,10 +146,12 @@ tokens that all conforming implementations MUST support. Instead, it merely
 specifies what any generic URI must look like, and what rules the system MUST
 follow.
 
+==== Artifact Rules
+
 in-toto artifact rules are a means to specify what artifacts the project owner
 expects in every step of the supply chain in the in-toto layout. in-toto
-provides the following rules that together attempt to describe the different
-types of operations or actions that supply chain functionaries carry out.
+provides the certain rules that together attempt to describe the different types
+of operations or actions that supply chain functionaries carry out.
 
 *MATCH Rule*
 
@@ -180,6 +182,13 @@ different checks by verifying if artifacts matching the pattern occur or do not
 occur in the materials or products sections of the relevant link. This does not
 involve resolving the pattern or URI into the artifact itself, and so this ITE
 does not affect the working of these rules.
+
+However, it is quite likely that the contents referred to using generic URIs
+change more frequently than the traditional artifacts in the filesystem. The
+expectation is that either these changes are recorded with link attestations of
+their own, making them part of the supply chain, or metadata is replaced by
+authorized functionaries. The security implications of frequently changing
+generic resources are discussed in the Security section below.
 
 [[motivation]]
 == Motivation

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -596,10 +596,9 @@ maintain that consistency throughout, ensuring a single root is maintained.
 Similarly, it is possible for generic URIs that point to remote locations to be
 redirected at times. In some cases, the resources are moved to a new location.
 For example, when a user changes their GitHub username, a redirect is setup for
-references to the old username. Similarly, when repositories are renamed, a
-redirect is setup to the new location. Implementors must be careful with
-redirects and must decide based on context and security considerations if the
-compliant system should follow them to the destination or not.
+references to the old username. Implementors must be careful with redirects and
+must decide based on context and security considerations if the compliant system
+should follow them to the destination or not.
 
 ==== Dynamic data in remote abstract entities
 

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -228,15 +228,18 @@ libraries.
 If in-toto metadata is generated using an implementation of in-toto conforming
 to this ITE, verification using a non-conforming implementation will likely
 fail. It is still possible for verification to continue if the inspections don't
-use generic URIs.
+use generic URIs. This is because the layout may contain inspections that use
+generic URIs.
 
 However, a conforming implementation should be capable of verifying in-toto
-metadata generated using a non-conforming implementation, as a conforming
-system must also conform to the main in-toto specification.
+metadata generated using a non-conforming implementation, as an ITE-4 conforming
+system must also conform to the actual in-toto specification.
 
 It's also possible two conforming systems are unable to verify the other's
 in-toto metadata as they're unaware of how to resolve certain URI tokens used by
-the other.
+the other. This is again because of the possibility of inspections containing
+URIs that the other system is unable to resolve and calculate cryptographic
+information for.
 
 [[security]]
 == Security

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -56,7 +56,7 @@ in-toto link metadata files currently look like this:
 ```
 {
     "_type": "link",
-    "_name": "<NAME>",
+    "name": "<NAME>",
     "command": "<COMMAND>",
     "materials": {
         "<PATH>": <HASH>,
@@ -92,7 +92,7 @@ This ITE proposes the following structure for the URI.
 `<scheme>:<hier-part>`
 
 This structure is derived from RFC 3986. The `scheme` defines the token or
-identifier for the type of resource the URI refers to . It can also contain
+identifier for the type of resource the URI refers to. It can also contain
 other relevant information that indicates how the resource can be accessed. The
 `hier-part` identifies the path or location of the resource.
 
@@ -134,7 +134,7 @@ documents, the URI can also be used to refer to other entities elsewhere in the
 document.
 
 Artifact Rules are a means to specify what artifacts the project owner expects
-in every step of the supply chain in the in-toto layout. in-toto povides the
+in every step of the supply chain in the in-toto layout. in-toto provides the
 following rules that together attempt to describe the different types of
 operations or actions that supply chain functionaries carry out.
 
@@ -245,7 +245,7 @@ It's important to note that filepaths are a form of URIs too, and can be
 represented with the `scheme` `file://`. We have also discovered that `MATCH`
 and other artifact rules use only the URI strings themselves to find the
 appropriate entries in the link metadata. The changes proposed in this ITE,
-therefore, have no effect on the security guarantees made by th in-toto
+therefore, have no effect on the security guarantees made by the in-toto
 specification.
 
 Implementing systems that conform to this ITE must, however, be careful with how

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -38,14 +38,14 @@ endif::[]
 
 This ITE proposes a generic Unique Resource Identifier (URI) scheme for in-toto
 artifacts. Currently, the in-toto specification only allows for files in the
-local filesystem to be the artifacts of link metadata. This ITE also defines the
-scheme for a generic URI and provides a behaviour of in-toto implementations
-that support generic URIs.
+local filesystem to be the artifacts of link metadata. This ITE defines the
+scheme for a generic URI and provides a description of the expected behaviour of
+in-toto implementations that support generic URIs.
 
 [[specification]]
 == Specification
 
-The current in-toto specification must be modified to provide support for the
+The current in-toto specification must be modified to provide support for
 generic URI schemes. The current specification allows only for files in the
 local filesystem to be set as artifacts. With the addition of other entities,
 the parts of the specification that directly interact or handle the artifacts
@@ -114,8 +114,8 @@ This can also instead use GitHub's API specific URI to refer to the same data.
 
 Both the above URIs refer to the same abstract entity - pull request 250 to
 in-toto's reference implementation. However, taken directly, they correspond to
-different data. Therefore, the implementing system must resolve the URI and use
-it consistently.
+different data. Therefore, the implementing system must resolve the URI and thus
+the artifact in a consistent manner.
 
 An example of the product field for link metadata with a generic URI is as
 follows:
@@ -354,7 +354,7 @@ use generic URIs.
 
 However, a conforming implementation should be capable of verifying in-toto
 metadata generated using a non-conforming implementation, as an ITE-4 conforming
-system must also conform to the actual in-toto specification.
+system MUST also conform to the actual in-toto specification.
 
 It's also possible two conforming systems may be unable to verify the other's
 in-toto metadata as they're unaware of how to resolve certain URI tokens used by
@@ -402,4 +402,3 @@ This ITE currently proposes no prototypes.
 
 * link:https://tools.ietf.org/html/rfc3986[Uniform Resource Identifier (URI): Generic Syntax]
 * link:https://github.com/in-toto/docs/blob/master/in-toto-spec.md[in-toto Specification]
-* link:https://pypi.org/project/rfc3986/[RFC 3986 library for Python]

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -42,6 +42,26 @@ local filesystem to be the artifacts of link metadata. This ITE also defines the
 scheme for a generic URI and provides a behaviour of in-toto implementations
 that support generic URIs.
 
+[[motivation]]
+== Motivation
+
+ITE 4 is motivated by the following use cases.
+
+==== Use Case 1: SPDX Document Identifiers
+
+The Software Package Data Exchange (SPDX) is an open standard for communicating
+software bill of material information such as components, licenses, copyrights,
+and security references. Each document is a comprehensive report that describes
+a software package in detail. They're composed of several entities that have
+unique identifiers. These identifiers can be used in in-toto metadata embedded
+in SPDX documents to refer to the respective entities.
+
+==== Use Case 2: GitHub Entities
+
+GitHub has more abstract entities such as Pull Requests and Issues. These
+entities can be referred to directly using the URI schemes proposed in this ITE
+and help provide attestations about this data.
+
 [[specification]]
 == Specification
 
@@ -83,9 +103,8 @@ The `materials` and `products` fields contain key-value pairs. The URI for each
 artifact is its path in the filesystem. With this ITE active, the artifact could
 instead have a generic URI which can be resolved to some external resource that
 is part of the supply chain. The URI MUST have a fixed structure and MUST
-contain all the information necessary for any verifier to obtain the resource it
-refers to. Therefore, any verifier MUST be able to take the URI in isolation and
-know how and where to find the artifact.
+contain all the information necessary for the verifier to resolve if any part of
+the verification workflow requires it.
 
 This ITE proposes the following structure for the URI.
 
@@ -112,10 +131,6 @@ This can also instead use GitHub's API specific URI to refer to the same data.
 
 `github+https://api.github.com/repos/in-toto/in-toto/pulls/250`
 
-The in-toto system generating link metadata for this artifact MUST be capable
-of recognizing that it possesses a generic URI, and the system MUST be able to
-resolve this resource and compute its cryptographic hash information. 
-
 An example of the product field for link metadata with a generic URI is as
 follows:
 
@@ -131,12 +146,19 @@ follows:
 Similarly, an SPDX URI can be used to directly fetch the corresponding documents
 from a specified location. For in-toto metadata that exist within SPDX
 documents, the URI can also be used to refer to other entities elsewhere in the
-document.
+document. Resolving such URIs that point to local entities elsewhere in the SPDX
+document is an implementation level detail - but it's clear that the URI
+contains all the information necessary to identify the entity in that context.
 
-Artifact Rules are a means to specify what artifacts the project owner expects
-in every step of the supply chain in the in-toto layout. in-toto provides the
-following rules that together attempt to describe the different types of
-operations or actions that supply chain functionaries carry out.
+It is important to note that this ITE doesn't mandate any specific generic URI
+tokens that all conforming implementations MUST support. Instead, it merely
+specifies what any generic URI must look like, and what rules the system MUST
+follow.
+
+in-toto artifact rules are a means to specify what artifacts the project owner
+expects in every step of the supply chain in the in-toto layout. in-toto
+provides the following rules that together attempt to describe the different
+types of operations or actions that supply chain functionaries carry out.
 
 ==== `MATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS) [IN <destination-path-prefix>] FROM <step>`
 
@@ -163,26 +185,6 @@ in-toto provides several other artifact rules - specifically `ALLOW`,
 check that the provided pattern exists are does not exist in the relevant link
 metadata, without ever resolving the pattern into the artifact itself.
 Therefore, this ITE does not affect the working of these rules.
-
-[[motivation]]
-== Motivation
-
-ITE 4 is motivated by the following use cases.
-
-==== Use Case 1: SPDX Document Identifiers
-
-The Software Package Data Exchange (SPDX) is an open standard for communicating
-software bill of material information such as components, licenses, copyrights,
-and security references. Each document is a comprehensive report that describes
-a software package in detail. They're composed of several entities that have
-unique identifiers. These identifiers can be used in in-toto metadata embedded
-in SPDX documents to refer to the respective entities.
-
-==== Use Case 2: GitHub Entities
-
-GitHub has more abstract entities such as Pull Requests and Issues. These
-entities can be referred to directly using the URI schemes proposed in this ITE
-and help provide attestations about this data.
 
 [[reasoning]]
 == Reasoning

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -197,6 +197,44 @@ their own, making them part of the supply chain, or metadata is replaced by
 authorized functionaries. The security implications of frequently changing
 generic resources are discussed in the Security section below.
 
+==== General Structure for URI Resolvers
+
+While the implementations of resolvers will vary wildly depending on the context
+they're written for, this ITE recommends they follow a certain structure that
+enables them to be reused by different stakeholders looking to hash the same
+abstract entities.
+
+```
+define hash_artifact(string generic_uri, list hash_algorithms) returns map \
+    hash_map
+    hashable_representation <- get_hashable_representation(generic_uri)
+    for each algorithm in hash_algorithms
+        hash_map[algorithm] <- algorithm_hash(hashable_representation)
+
+define get_hashable_representation(string generic_uri) returns string \
+    hashable_representation
+```
+
+`get_hashable_representation` is the fundamental component of any implementation
+that complies with this ITE. It is responsible for generating consistent
+representations of abstract entities while simultaneously maintaining their core
+properties. For example, an implementation that is capable of hashing GitHub
+entities may choose to use a subsection of the contents obtained using the
+official API, which returns JSON representations containing different properties
+of the entities. It is important for these representations to be consistent for
+a particular entity and they must be generated keeping in mind the different
+sources of non-determinism as highlighted in the Appendix. This component is
+also responsible for handling missing resources safely.
+
+Being able to get some hashable representation of abstract entities is necessary
+for in-toto inspections to verify contents as the context demands it. Therefore,
+it should be possible for implementations to use the method in scenarios other
+than just the recording of hashes of an artifact.
+
+`hash_artifact` closely mirrors the general workflow of hashing artifacts in the
+filesystem, and is similar to how the in-toto reference implementations
+currently work.
+
 [[motivation]]
 == Motivation
 

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -201,9 +201,9 @@ are also part of the Consortium for Information and Software Quality (CISQ) and
 Object Management Group's (OMG) working group on
 link:https://www.it-cisq.org/software-bill-of-materials/index.htm[Tool-to-tool Software Bill of Materials Exchange].
 
-SPDX documents composed of several entities that have unique identifiers. These
-identifiers can be used in in-toto metadata embedded in SPDX documents to refer
-to the respective entities.
+SPDX documents are composed of several entities that have unique identifiers.
+These identifiers can be used in in-toto metadata embedded in SPDX documents to
+refer to the respective entities.
 
 ===== in-toto link attestation for packaging SPDX files into an SPDX package
 
@@ -317,7 +317,7 @@ commit. The attestation could look something like:
 This step is accepting the pull request as a material and is recording the merge
 commit as a product.
 
-===== in-toto link attesation for GitHub Actions building from a merge commit
+===== in-toto link attestation for GitHub Actions building from a merge commit
 
 GitHub Actions can be used to set up a workflow for continuous integration (CI).
 Workflows can be triggered on push and an attestation can be generated for the

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -90,10 +90,11 @@ This ITE proposes the following structure for the URI.
 
 `<scheme>:<hier-part>`
 
-This structure is derived from RFC 3986. The `scheme` defines the token or
-identifier for the type of resource the URI refers to. It can also contain
-other relevant information that indicates how the resource can be accessed. The
-`hier-part` identifies the path or location of the resource.
+This structure is derived from
+link:https://tools.ietf.org/html/rfc3986[RFC 3986]. The `scheme` defines the
+token or identifier for the type of resource the URI refers to. It can also
+contain other relevant information that indicates how the resource can be
+accessed. The `hier-part` identifies the path or location of the resource.
 
 A compliant in-toto system must be capable of generating link metadata with
 artifacts that have generic URI references. Therefore, this system must also be

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -118,7 +118,8 @@ This can also instead use GitHub's API specific URI to refer to the same data.
 Both the above URIs refer to the same abstract entity - pull request 250 to
 in-toto's reference implementation. However, taken directly, they correspond to
 different data. Therefore, the implementing system must resolve the URI and thus
-the artifact in a consistent manner.
+the artifact in a consistent manner. We discuss this and other sources of
+non-determinism in the Appendix.
 
 An example of the product field for link metadata with a generic URI is as
 follows:
@@ -378,7 +379,7 @@ information for.
 [[security]]
 == Security
 
-It's important to note that filepaths are a form of URIs too, and can be
+It's important to note that file paths are a form of URIs too, and can be
 represented with the `scheme` `file://`. We have also discovered that `MATCH`
 and other artifact rules use only the URI strings themselves to find the
 appropriate entries in the link metadata. The changes proposed in this ITE,
@@ -418,3 +419,44 @@ This ITE currently proposes no prototypes.
 * link:https://github.com/cdfoundation/sig-security-sbom[CD Foundation Special Interest Group on Software Bill of Materials]
 * link:https://www.ntia.doc.gov/SoftwareTransparency[NTIA Software Component Transparency]
 * link:https://www.it-cisq.org/software-bill-of-materials/index.htm[CISQ/OMG Tool-to-tool Software Bill of Materials Exchange]
+
+[[appendix]]
+== Appendix: Sources of Non-Determinism
+
+The changes proposed in this ITE can lead to some non-determinism in the data
+represented by artifacts. We discuss *some* of them here, and emphasize that
+it is important for implementors to keep these factors in mind while designing
+compliant systems.
+
+==== Non-Unique URIs for abstract resources
+
+It is possible for an abstract entity to have more than one URI. An example of
+this is with GitHub entities. A GitHub pull request can be identified by its web
+URL or by its API URL. Both of them refer to the same abstract entity - a
+specific pull request - however, the data fetched by the resolver are vastly
+different, and even encoded differently. It is out of the scope of this ITE to
+specify how to handle these situations. Instead, implementors must take care to
+maintain consistency with the generic URIs and the formats used to refer to
+abstract entities, and ensure that link attestations are compliant with these
+policies. Alternatively, parameter substitution can be leveraged to create
+defaults for entities with multiple URIs. In GitHub's example, this would take
+the form of using parameter substitution to decide the root of the URI and
+maintain that consistency throughout, ensuring a single root is maintained.
+
+==== Redirects
+
+Similarly, it is possible for generic URIs that point to remote locations to be
+redirected at times. In some cases, the resources are moved to a new location.
+For example, when a user changes their GitHub username, a redirect is setup for
+references to the old username. Similarly, when repositories are renamed, a
+redirect is setup to the new location. Implementors must be careful with
+redirects and must decide based on context and security considerations if the
+compliant system should follow them to the destination or not.
+
+==== Dynamic data in remote abstract entities
+
+Abstract entities can have information that is dynamically populated and may
+change unexpectedly with time. This can cause failure in in-toto verification
+as these changes may not be encoded using the artifact rules. This can take the
+form of components that rely on the current time to populate certain information
+or scripts that populate information from other remote sources.

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -187,7 +187,7 @@ ITE-4 is motivated by the following use cases.
 
 ==== Use Case 1: SPDX Document Identifiers
 
-The Software Package Data Exchange (SPDX) is an open standard for communicating
+Software Package Data Exchange (SPDX) is an open standard for communicating
 software bill of materials (SBoM) information such as components, licenses,
 copyrights, and security references. Each document is a comprehensive report
 that describes a software package in detail. SPDX is a part of the broader
@@ -195,6 +195,10 @@ discussions with Continuous Delivery (CD) Foundation's
 link:https://github.com/cdfoundation/sig-security-sbom[Special Interest Group for Software Bill of Materials],
 as well as with the National Telecommunication and Information Administration's
 (NTIA) link:https://www.ntia.doc.gov/SoftwareTransparency[Software Component Transparency].
+SPDX and in-toto, along with representatives from NTIA and other stakeholders,
+are also part of the Consortium for Information and Software Quality (CISQ) and
+Object Management Group's (OMG) working group on
+link:https://www.it-cisq.org/software-bill-of-materials/index.htm[Tool-to-tool Software Bill of Materials Exchange].
 
 SPDX documents composed of several entities that have unique identifiers. These
 identifiers can be used in in-toto metadata embedded in SPDX documents to refer
@@ -413,3 +417,4 @@ This ITE currently proposes no prototypes.
 * link:https://github.com/in-toto/docs/blob/master/in-toto-spec.md[in-toto Specification]
 * link:https://github.com/cdfoundation/sig-security-sbom[CD Foundation Special Interest Group on Software Bill of Materials]
 * link:https://www.ntia.doc.gov/SoftwareTransparency[NTIA Software Component Transparency]
+* link:https://www.it-cisq.org/software-bill-of-materials/index.htm[CISQ/OMG Tool-to-tool Software Bill of Materials Exchange]

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -296,7 +296,7 @@ build that as a result.
 
 This ITE proposes a change in the URI scheme of artifacts in in-toto metadata.
 The proposed change closely matches the URI structure laid out in RFC 3986. The
-URI structure propsed in that document is widely accepted and is versatile
+URI structure proposed in that document is widely accepted and is versatile
 enough to allow for a wide variety of references. It is also easy to implement
 and extend support for due to the presence of a large number of standard
 libraries.

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -429,7 +429,8 @@ in the local filesystem. In the above example, for a public repository, *any*
 GitHub user can comment on a pull request, so for an implementation that also
 considers comments when recording the hash, any user can potentially cause a
 failure of the verification workflow. This can potentially be leveraged by a
-malicious actor to target automated pipelines that rely on in-toto verification.
+malicious actor to target automated pipelines that rely on in-toto verification,
+using a Denial of Service attack.
 
 Finally, our analysis showed that verification of artifact rules specified in
 in-toto layouts use the hashes recorded while generating the link metadata and

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -265,7 +265,7 @@ commit as a product.
 
 GitHub Actions can be used to set up a workflow for continuous integration (CI).
 Workflows can be triggered on push and an attestation can be generated for the
-build that as a result.
+resulting build and CI report.
 
 
 ```

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -205,7 +205,7 @@ commit. The attestation could look something like:
 {
     "_type": "link",
     "name": "merge-pull-request-250",
-    "command": "<COMMAND>",
+    "command": "",
     "materials": {
         "github+https://github.com/in-toto/in-toto/pull/250": <HASH>
     },
@@ -239,7 +239,7 @@ build that as a result.
 {
     "_type": "link",
     "name": "github-actions-build-pull-request-250",
-    "command": "<COMMAND>",
+    "command": "",
     "materials": {
         "github+https://github.com/in-toto/in-toto/commit/f1c5d201887e226cadac5792a203ac3eae347add": <HASH>
     },

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -185,11 +185,11 @@ ITE 4 is motivated by the following use cases.
 ==== Use Case 1: SPDX Document Identifiers
 
 The Software Package Data Exchange (SPDX) is an open standard for communicating
-software bill of material information such as components, licenses, copyrights,
-and security references. Each document is a comprehensive report that describes
-a software package in detail. They're composed of several entities that have
-unique identifiers. These identifiers can be used in in-toto metadata embedded
-in SPDX documents to refer to the respective entities.
+software bill of materials (SBoM) information such as components, licenses,
+copyrights, and security references. Each document is a comprehensive report
+that describes a software package in detail. They're composed of several
+entities that have unique identifiers. These identifiers can be used in in-toto
+metadata embedded in SPDX documents to refer to the respective entities.
 
 ===== in-toto link attestation for packaging SPDX files into an SPDX package
 

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -37,10 +37,12 @@ endif::[]
 == Abstract
 
 This ITE proposes a generic Unique Resource Identifier (URI) scheme for in-toto
-artifacts. Currently, the in-toto specification only allows for files in the
-local filesystem to be the artifacts of link metadata. This ITE defines the
-scheme for a generic URI and provides a description of the expected behaviour of
-in-toto implementations that support generic URIs.
+artifacts. Currently, the
+link:https://github.com/in-toto/docs/blob/master/in-toto-spec.md[in-toto specification]
+only allows for files in the local filesystem to be the artifacts of link
+metadata. This ITE defines the scheme for a generic URI and provides a
+description of the expected behaviour of in-toto implementations that support
+generic URIs.
 
 [[specification]]
 == Specification
@@ -188,9 +190,15 @@ ITE-4 is motivated by the following use cases.
 The Software Package Data Exchange (SPDX) is an open standard for communicating
 software bill of materials (SBoM) information such as components, licenses,
 copyrights, and security references. Each document is a comprehensive report
-that describes a software package in detail. They're composed of several
-entities that have unique identifiers. These identifiers can be used in in-toto
-metadata embedded in SPDX documents to refer to the respective entities.
+that describes a software package in detail. SPDX is a part of the broader
+discussions with Continuous Delivery (CD) Foundation's
+link:https://github.com/cdfoundation/sig-security-sbom[Special Interest Group for Software Bill of Materials],
+as well as with the National Telecommunication and Information Administration's
+(NTIA) link:https://www.ntia.doc.gov/SoftwareTransparency[Software Component Transparency].
+
+SPDX documents composed of several entities that have unique identifiers. These
+identifiers can be used in in-toto metadata embedded in SPDX documents to refer
+to the respective entities.
 
 ===== in-toto link attestation for packaging SPDX files into an SPDX package
 
@@ -403,3 +411,5 @@ This ITE currently proposes no prototypes.
 
 * link:https://tools.ietf.org/html/rfc3986[Uniform Resource Identifier (URI): Generic Syntax]
 * link:https://github.com/in-toto/docs/blob/master/in-toto-spec.md[in-toto Specification]
+* link:https://github.com/cdfoundation/sig-security-sbom[CD Foundation Special Interest Group on Software Bill of Materials]
+* link:https://www.ntia.doc.gov/SoftwareTransparency[NTIA Software Component Transparency]

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -314,16 +314,15 @@ libraries.
 == Backwards Compatibility
 
 If in-toto metadata is generated using an implementation of in-toto conforming
-to this ITE, verification using a non-conforming implementation will likely
-fail. It is still possible for verification to continue if the inspections don't
-use generic URIs. This is because the layout may contain inspections that use
-generic URIs.
+to this ITE, verification using a non-conforming implementation can fail. It is
+possible for the verification workflow to progress if the inspections don't
+use generic URIs.
 
 However, a conforming implementation should be capable of verifying in-toto
 metadata generated using a non-conforming implementation, as an ITE-4 conforming
 system must also conform to the actual in-toto specification.
 
-It's also possible two conforming systems are unable to verify the other's
+It's also possible two conforming systems may be unable to verify the other's
 in-toto metadata as they're unaware of how to resolve certain URI tokens used by
 the other. This is again because of the possibility of inspections containing
 URIs that the other system is unable to resolve and calculate cryptographic

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -138,7 +138,7 @@ in every step of the supply chain in the in-toto layout. in-toto provides the
 following rules that together attempt to describe the different types of
 operations or actions that supply chain functionaries carry out.
 
-=== `MATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS) [IN <destination-path-prefix>] FROM <step>`
+==== `MATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS) [IN <destination-path-prefix>] FROM <step>`
 
 The Match rule is a convenient way to match artifacts (either in materials or
 products depending on where the rule is specified) with artifacts from other
@@ -156,41 +156,13 @@ is as follows:
 `MATCH pull/250 IN github+https://github.com/in-toto/in-toto/ WITH PRODUCTS IN
 github+https://github.com/in-toto/in-toto-golang/pull/ FROM merge-go-repository`
 
-=== `ALLOW <pattern>`
+==== Other artifact rules
 
-The Allow rule specifies an artifact matched by the rule is allowed as a
-material or product of the particular step. This rule is not affected by this
-ITE.
-
-=== `DISALLOW <pattern>`
-
-The Disallow rule specifies an artifact matched by the Rule is not allowed as a
-material or product of the particular step. This rule is not affected by this
-ITE.
-
-=== `CREATE <pattern>`
-
-The Create rule specifies that an artifact matched by this rule MUST not appear
-as a material of the particular step - it MUST instead be created as part of
-executing this step of the supply chain. This rule is not affected by this ITE.
-
-=== `DELETE <pattern>`
-
-The Delete rule specifies that an artifact matched by this rule MUST not appear
-as a product of the particular step - it MUST instead be deleted as part of
-executing this step of the supply chain. This rule is not affected by this ITE.
-
-=== `REQUIRE <pattern>`
-
-The Require rule specifies that an artifact matched by this rule MUST appear as
-a material or product of the particular step. This rule is not affected by this
-ITE.
-
-=== `MODIFY <pattern>`
-
-The Modify rule specifies that an artifact matched by this rule MUST appear as
-both a material and product of the step, and the hash of the artifact MUST
-differ indicating the execution of the step changed the artifact.
+in-toto provides several other artifact rules - specifically `ALLOW`,
+`DISALLOW`, `CREATE`, `DELETE`, `REQUIRE`, and `MODIFY`. All these rules merely
+check that the provided pattern exists are does not exist in the relevant link
+metadata, without ever resolving the pattern into the artifact itself.
+Therefore, this ITE does not affect the working of these rules.
 
 [[motivation]]
 == Motivation

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -84,9 +84,9 @@ in-toto link metadata files currently look like this:
 The `materials` and `products` fields contain key-value pairs. The URI for each
 artifact is its path in the filesystem. With this ITE active, the artifact could
 instead have a generic URI which can be resolved to some external resource that
-is part of the supply chain. The URI MUST have a fixed structure and MUST
-contain all the information necessary for the verifier to resolve if any part of
-the verification workflow requires it.
+is part of the supply chain. Such a generic URI MUST have a fixed structure and
+MUST contain all the information necessary for the verifier to resolve if any
+part of the verification workflow requires it.
 
 This ITE proposes the following structure for the URI.
 

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -129,12 +129,13 @@ follows:
 }
 ```
 
-Similarly, an SPDX URI can be used to directly fetch the corresponding documents
-from a specified location. For in-toto metadata that exist within SPDX
+Similarly, a generic URI can be used to refer to other abstrat entities like an
+SPDX element. The URI can be used to directly fetch the corresponding documents
+from a specified location. For in-toto metadata that are embedded within SPDX
 documents, the URI can also be used to refer to other entities elsewhere in the
 document. Resolving such URIs that point to local entities elsewhere in the SPDX
-document is an implementation level detail - but it's clear that the URI
-contains all the information necessary to identify the entity in that context.
+document is an implementation level detail - but it's clear that the URI must
+contain all the information necessary to identify the entity in that context.
 
 It is important to note that this ITE doesn't mandate any specific generic URI
 tokens that all conforming implementations MUST support. Instead, it merely

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -205,15 +205,20 @@ enables them to be reused by different stakeholders looking to hash the same
 abstract entities.
 
 ```
-define hash_artifact(string generic_uri, list hash_algorithms) returns map \
-    hash_map
-    hashable_representation <- get_hashable_representation(generic_uri)
-    for each algorithm in hash_algorithms
-        hash_map[algorithm] <- algorithm_hash(hashable_representation)
+define hash_artifacts(string generic_uri, list hash_algorithms, kwargs) \
+    returns map artifact_hash_map
 
-define get_hashable_representation(string generic_uri) returns string \
+define resolve_uri(string generic_uri, kwargs) returns list contained_uris
+
+define get_hashable_representation(string generic_uri, kwargs) returns bytes \
     hashable_representation
 ```
+
+`hash_artifacts` closely mirrors the general workflow of hashing artifacts in
+the filesystem, and is similar to how the in-toto reference implementations
+currently work. It requires generic artifacts to have a hashable representation
+of themselves. The method must return a map that contains all artifacts and
+their corresponding hash objects.
 
 `get_hashable_representation` is the fundamental component of any implementation
 that complies with this ITE. It is responsible for generating consistent
@@ -223,17 +228,21 @@ entities may choose to use a subsection of the contents obtained using the
 official API, which returns JSON representations containing different properties
 of the entities. It is important for these representations to be consistent for
 a particular entity and they must be generated keeping in mind the different
-sources of non-determinism as highlighted in the Appendix. This component is
-also responsible for handling missing resources safely.
+sources of non-determinism as highlighted in the Appendix. It's also necessary
+for this method to handle missing resources safely.
 
 Being able to get some hashable representation of abstract entities is necessary
 for in-toto inspections to verify contents as the context demands it. Therefore,
 it should be possible for implementations to use the method in scenarios other
 than just the recording of hashes of an artifact.
 
-`hash_artifact` closely mirrors the general workflow of hashing artifacts in the
-filesystem, and is similar to how the in-toto reference implementations
-currently work.
+It is quite likely that a generic URI specified may point to a collection of
+abstract entities. In the present framework where all artifacts are part of the
+filesystem, this is akin to using the path of a directory to record all the
+contents of the directory as the actual artifacts of the step. Therefore,
+`resolve_uri` is used to resolve such URIs to multiple different artifacts that
+they contain. Each of them must be hashed using their corresponding hashable
+representations.
 
 [[motivation]]
 == Motivation

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -129,7 +129,7 @@ follows:
 }
 ```
 
-Similarly, a generic URI can be used to refer to other abstrat entities like an
+Similarly, a generic URI can be used to refer to other abstract entities like an
 SPDX element. The URI can be used to directly fetch the corresponding documents
 from a specified location. For in-toto metadata that are embedded within SPDX
 documents, the URI can also be used to refer to other entities elsewhere in the

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -411,6 +411,9 @@ if the resource is controlled by a malicious actor. Implementors must also take
 care to ensure they handle situations where a resource may be unavailable, and
 fail appropriately.
 
+NOTE: There is an ongoing discussion about limiting the scope of this ITE to
+static or unchanging resources. Thread: https://github.com/in-toto/ITE/issues/7
+
 Further, it is likely that abstract resources change more frequently, both in
 content and format, and implementors must take care to identify how these
 contents are recorded, as well what specific information is recorded for a

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -99,17 +99,23 @@ A compliant in-toto system must be capable of generating link metadata with
 artifacts that have generic URI references. Therefore, this system must also be
 capable of resolving this URI and calculating cryptographic hashes of these
 artifacts. It's important to note that the contents of the resource are hashed,
-as opposed to the URI itself.
+as opposed to the URI itself. This ITE doesn't specify how the contents are
+resolved and hashed by the system generating the metadata for the relevant
+abstract entities. All it specifies is that the resolution and the URI itself
+must be consistent in all metadata.
 
-To that end, it's important for a URI scheme to have a single mapping for the
-service it refers to. Consider an example of a GitHub specific resource - a pull
-request or an issue.
+Consider an example of a GitHub specific resource - a pull request or an issue.
 
 `github+https://github.com/in-toto/in-toto/pull/250`
 
 This can also instead use GitHub's API specific URI to refer to the same data.
 
 `github+https://api.github.com/repos/in-toto/in-toto/pulls/250`
+
+Both the above URIs refer to the same abstract entity - pull request 250 to
+in-toto's reference implementation. However, taken directly, they correspond to
+different data. Therefore, the implementing system must resolve the URI and use
+it consistently.
 
 An example of the product field for link metadata with a generic URI is as
 follows:
@@ -142,7 +148,8 @@ types of operations or actions that supply chain functionaries carry out.
 
 *MATCH Rule*
 
-`MATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS) [IN <destination-path-prefix>] FROM <step>`
+`MATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS) [IN
+<destination-path-prefix>] FROM <step>`
 
 The Match rule is a convenient way to match artifacts (either in materials or
 products depending on where the rule is specified) with artifacts from other
@@ -157,8 +164,8 @@ subtracted from the URI strings. Therefore, we conclude that the functioning of
 the rule doesn't change with this ITE. An example `MATCH` rule with generic URIs
 is as follows:
 
-`MATCH pull/250 IN github+https://github.com/in-toto/in-toto/ WITH PRODUCTS IN
-github+https://github.com/in-toto/in-toto-golang/pull/ FROM merge-go-repository`
+`MATCH commit/* IN github+https://github.com/in-toto/in-toto/ WITH PRODUCTS IN
+github+https://github.com/in-toto/in-toto FROM merge-pull-request-250`
 
 *Other artifact rules*
 
@@ -332,7 +339,9 @@ therefore, have no effect on the security guarantees made by the in-toto
 specification.
 
 Implementing systems that conform to this ITE must, however, be careful with how
-they compute cryptographic hashes of abstract entities.
+they compute cryptographic hashes of abstract entities. The implementors must
+understand the abstract entities they are hashing so as to be able to do so
+consistently.
 
 [[infrastructure-requirements]]
 == Infrastructure Requirements

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -152,7 +152,7 @@ types of operations or actions that supply chain functionaries carry out.
 `MATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS) [IN
 <destination-path-prefix>] FROM <step>`
 
-The Match rule is a convenient way to match artifacts (either in materials or
+The `MATCH` rule is a convenient way to match artifacts (either in materials or
 products depending on where the rule is specified) with artifacts from other
 steps in the supply chain, allowing owners to establish a flow of artifacts
 between steps in the software supply chain.
@@ -180,7 +180,7 @@ does not affect the working of these rules.
 [[motivation]]
 == Motivation
 
-ITE 4 is motivated by the following use cases.
+ITE-4 is motivated by the following use cases.
 
 ==== Use Case 1: SPDX Document Identifiers
 

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -229,13 +229,47 @@ GitHub has more abstract entities such as Pull Requests and Issues. These
 entities can be referred to directly using the URI schemes proposed in this ITE
 and help provide attestations about these artifacts. Consider:
 
-===== in-toto link attestation for merging a pull request into `master`
+===== in-toto link attestation for creating a pull request
 
 A pull request is a proposal to make changes to a repository. Changes are either
 made on a separate branch on the same repository or a branch on a fork of the
 repository and the pull request is a proposal to merge these changes into the
-main repository. The act of merging a pull request is performed by an authorized
-member of the development team of the repository.
+main repository.
+
+```
+{
+    "_type": "link",
+    "name": "pull-request-250",
+    "command": "",
+    "materials": {
+        "github+https://github.com/in-toto/in-toto/commit/3371c93699785ba5907411a321ce82c59cb127fa": <HASH>,
+        "...": "..."
+    },
+    "products": {
+        "github+https://github.com/in-toto/in-toto/pull/250": <HASH>
+    },
+    "byproducts": {
+        "stderr": "",
+        "stdout": "",
+        "return-value": ""
+    },
+    "environment": {
+        "variables": "",
+        "filesystem": "",
+        "workdir": ""
+    }
+}
+```
+
+The materials aren't limited to the commits that make up a pull request, but can
+also contain other elements such as reviews or other comments that make up a
+discussion, as well as approvals from maintainers. It really depends on how the
+implementor, perhaps GitHub, chooses to define the components of a pull request.
+
+===== in-toto link attestation for merging a pull request into `master`
+
+The act of merging a pull request is performed by an authorized member of the
+development team of the repository.
 
 By default, the commits that make up the change are integrated into the target
 branch and an additional merge commit is created to indicate the act of merging.

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -534,11 +534,10 @@ malicious actor to target automated pipelines that rely on in-toto verification,
 using a Denial of Service attack.
 
 Finally, our analysis showed that verification of artifact rules specified in
-in-toto layouts use the hashes recorded while generating the link metadata and
-do not record afresh any of the hashes. So the security properties of artifact
-rules verification rely on the above points - ensuring the hashes are recorded
-correctly for a given context. The change in the URI format has no direct impact
-on the artifact rules and their verification.
+in-toto layouts rely on the hashes recorded while generating link metadata for
+steps and inspections, and do not record any hashes afresh. Therefore, while the
+changes proposed in this ITE impact the resolving of artifacts and the recording
+of their hashes, they do not change how artifact rules are verified.
 
 [[infrastructure-requirements]]
 == Infrastructure Requirements

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -42,26 +42,6 @@ local filesystem to be the artifacts of link metadata. This ITE also defines the
 scheme for a generic URI and provides a behaviour of in-toto implementations
 that support generic URIs.
 
-[[motivation]]
-== Motivation
-
-ITE 4 is motivated by the following use cases.
-
-==== Use Case 1: SPDX Document Identifiers
-
-The Software Package Data Exchange (SPDX) is an open standard for communicating
-software bill of material information such as components, licenses, copyrights,
-and security references. Each document is a comprehensive report that describes
-a software package in detail. They're composed of several entities that have
-unique identifiers. These identifiers can be used in in-toto metadata embedded
-in SPDX documents to refer to the respective entities.
-
-==== Use Case 2: GitHub Entities
-
-GitHub has more abstract entities such as Pull Requests and Issues. These
-entities can be referred to directly using the URI schemes proposed in this ITE
-and help provide attestations about this data.
-
 [[specification]]
 == Specification
 
@@ -160,7 +140,9 @@ expects in every step of the supply chain in the in-toto layout. in-toto
 provides the following rules that together attempt to describe the different
 types of operations or actions that supply chain functionaries carry out.
 
-==== `MATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS) [IN <destination-path-prefix>] FROM <step>`
+*MATCH Rule*
+
+`MATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS) [IN <destination-path-prefix>] FROM <step>`
 
 The Match rule is a convenient way to match artifacts (either in materials or
 products depending on where the rule is specified) with artifacts from other
@@ -178,7 +160,7 @@ is as follows:
 `MATCH pull/250 IN github+https://github.com/in-toto/in-toto/ WITH PRODUCTS IN
 github+https://github.com/in-toto/in-toto-golang/pull/ FROM merge-go-repository`
 
-==== Other artifact rules
+*Other artifact rules*
 
 in-toto provides several other artifact rules - specifically `ALLOW`,
 `DISALLOW`, `CREATE`, `DELETE`, `REQUIRE`, and `MODIFY`. All these rules merely
@@ -186,10 +168,27 @@ check that the provided pattern exists are does not exist in the relevant link
 metadata, without ever resolving the pattern into the artifact itself.
 Therefore, this ITE does not affect the working of these rules.
 
-[[example-uses]]
-== Example Uses
+[[motivation]]
+== Motivation
 
-==== GitHub: Attestations for merging a pull request into `master`
+ITE 4 is motivated by the following use cases.
+
+==== Use Case 1: SPDX Document Identifiers
+
+The Software Package Data Exchange (SPDX) is an open standard for communicating
+software bill of material information such as components, licenses, copyrights,
+and security references. Each document is a comprehensive report that describes
+a software package in detail. They're composed of several entities that have
+unique identifiers. These identifiers can be used in in-toto metadata embedded
+in SPDX documents to refer to the respective entities.
+
+==== Use Case 2: GitHub Entities
+
+GitHub has more abstract entities such as Pull Requests and Issues. These
+entities can be referred to directly using the URI schemes proposed in this ITE
+and help provide attestations about these artifacts. Consider:
+
+===== Attestations for merging a pull request into `master`
 
 A pull request is a proposal to make changes to a repository. Changes are either
 made on a separate branch on the same repository or a branch on a fork of the
@@ -229,7 +228,7 @@ commit. The attestation could look something like:
 This step is accepting the pull request as a material and is recording the merge
 commit as a product.
 
-==== GitHub: Attestations for GitHub Actions building from a merge commit
+===== Attestations for GitHub Actions building from a merge commit
 
 GitHub Actions can be used to set up a workflow for continuous integration (CI).
 Workflows can be triggered on push and an attestation can be generated for the

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -82,7 +82,7 @@ in-toto link metadata files currently look like this:
 ```
 
 The `materials` and `products` fields contain key-value pairs. The URI for each
-artifact is its path in the filesystem. With this ITE active, the artifact could
+artifact is its path in the filesystem. With this ITE active, the artifact MAY
 instead have a generic URI which can be resolved to some external resource that
 is part of the supply chain. Such a generic URI MUST have a fixed structure and
 MUST contain all the information necessary for the verifier to resolve if any
@@ -98,14 +98,14 @@ token or identifier for the type of resource the URI refers to. It can also
 contain other relevant information that indicates how the resource can be
 accessed. The `hier-part` identifies the path or location of the resource.
 
-A compliant in-toto system must be capable of generating link metadata with
-artifacts that have generic URI references. Therefore, this system must also be
+A compliant in-toto system MUST be capable of generating link metadata with
+artifacts that have generic URI references. Therefore, this system MUST also be
 capable of resolving this URI and calculating cryptographic hashes of these
 artifacts. It's important to note that the contents of the resource are hashed,
 as opposed to the URI itself. This ITE doesn't specify how the contents are
 resolved and hashed by the system generating the metadata for the relevant
 abstract entities. All it specifies is that the resolution and the URI itself
-must be consistent in all metadata.
+MUST be consistent in all metadata.
 
 Consider an example of a GitHub specific resource - a pull request or an issue.
 
@@ -117,7 +117,7 @@ This can also instead use GitHub's API specific URI to refer to the same data.
 
 Both the above URIs refer to the same abstract entity - pull request 250 to
 in-toto's reference implementation. However, taken directly, they correspond to
-different data. Therefore, the implementing system must resolve the URI and thus
+different data. Therefore, the implementing system MUST resolve the URI and thus
 the artifact in a consistent manner. We discuss this and other sources of
 non-determinism in the Appendix.
 
@@ -138,12 +138,12 @@ SPDX element. The URI can be used to directly fetch the corresponding documents
 from a specified location. For in-toto metadata that are embedded within SPDX
 documents, the URI can also be used to refer to other entities elsewhere in the
 document. Resolving such URIs that point to local entities elsewhere in the SPDX
-document is an implementation level detail - but it's clear that the URI must
+document is an implementation level detail - but it's clear that the URI MUST
 contain all the information necessary to identify the entity in that context.
 
 It is important to note that this ITE doesn't mandate any specific generic URI
 tokens that all conforming implementations MUST support. Instead, it merely
-specifies what any generic URI must look like, and what rules the system MUST
+specifies what any generic URI MUST look like, and what rules the system MUST
 follow.
 
 ==== Artifact Rules
@@ -375,7 +375,7 @@ to this ITE, verification using a non-conforming implementation can fail. It is
 possible for the verification workflow to progress if the inspections don't
 use generic URIs.
 
-However, a conforming implementation should be capable of verifying in-toto
+However, a conforming implementation SHOULD be capable of verifying in-toto
 metadata generated using a non-conforming implementation, as an ITE-4 conforming
 system MUST also conform to the actual in-toto specification.
 

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -1,0 +1,230 @@
+= ITE-4: Generic URI Schemes for in-toto
+:source-highlighter: pygments
+:toc: preamble
+:toclevels: 2
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
+.Metadata
+[cols="2"]
+|===
+| ITE
+| 4
+
+| Title
+| Generic URI Schemes for in-toto
+
+| Sponsor
+| link:https://github.com/santiagotorres[Santiago Torres-Arias]
+
+| Status
+| Draft :speech_balloon:
+
+| Type
+| Standards
+
+| Created
+| 2019-09-30
+
+|===
+
+[[abstract]]
+== Abstract
+
+This ITE proposes a generic Unique Resource Identifier (URI) scheme for in-toto
+artifacts. Currently, the in-toto specification only allows for files in the
+local filesystem to be the artifacts of link metadata. This ITE also defines the
+scheme for a generic URI and analyzes the impact of intriducing generic URIs on
+the larger in-toto specification.
+
+[[specification]]
+== Specification
+
+in-toto link metadata files currently look like this:
+
+```
+{
+    "_type": "link",
+    "_name": "<NAME>",
+    "command": "<COMMAND>",
+    "materials": {
+        "<PATH>": <HASH>,
+        "...": ...
+    },
+    "products": {
+        "<PATH>": <HASH>,
+        "...": ...
+    },
+    "byproducts": {
+        "stderr": "<STDERR>",
+        "stdout": "<STDOUT>",
+        "return-value": "<RETURN-VALUE>"
+    },
+    "environment": {
+        "variables": "<ENV>",
+        "filesystem": "<FS>",
+        "workdir": "<PWD>"
+    }
+}
+```
+
+The `materials` and `products` fields contain key-value pairs. The URI for each
+artifact is its path in the filesystem. With this ITE active, the artifact could
+instead have a generic URI which can be resolved to some external resource that
+is part of the supply chain. The URI must have a fixed structure and must
+contain all the information necessary for any verifier to obtain the resource it
+refers to. Therefore, any verifier must be able to take the URI in isolation and
+know how and where to find the artifact.
+
+This ITE proposes the following structure for the URI.
+
+`<URI Identifier/Token>+<Transport Protocol>://<Location>`
+
+The URI Identifier must be unique and the verifier must know how to resolve all
+relevant identifiers. Let's take the example of a GitHub specific artifact. If
+the artifact is a pull request, the URI could be as simple as:
+
+`github+https://github.com/in-toto/in-toto/pull/250`
+
+Inspections are carried out during the verification workflow but essentially
+make use of the in-toto run workflow. Therefore, the system must know how to
+resolve these URIs and appropriately record them in the link metadata generated
+for the inspection. To that end, a resolver must be capable of:
+
+- `compute_hash` - This operation must know how to use the transport and
+location specified in the URI to serialize the target artifact and compute its
+hash. The implementation of this is very specific to each individual type of
+entity.
+
+The above operations can be expanded to fetch SPDX licenses and entire
+documents. An SPDX license URI can be used to directly fetch the corresponding
+license file from the SPDX website. On the other hand, SPDX documents must be
+fetched from wherever the document publisher has made it available, and the
+verification process should validate if the document matches a particular
+version of the SPDX specification. These are implementation specific details.
+
+This ITE doesn't limit the available operations - it merely specifies the
+mandatory operations a resolver must provide to allow all conforming in-toto
+verification implementations to be able to verify metadata. Additional methods
+can be provided which custom in-toto implementations can use for their specific
+purposes.
+
+==== Implications for the existing in-toto specification
+
+The current in-toto specification must be modified to provide support for the
+generic URI schemes. The current specification allows only for files in the
+local filesystem to be set as artifacts. With the addition of other entities,
+the parts of the specification that directly interact or handle the artifacts
+must be updated.
+
+Artifact Rules are a means to specify what artifacts the project owner expects
+in every step of the supply chain. Here is the analysis of the impact on each:
+
+- `MATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS) [IN
+<destination-path-prefix>] FROM <step>` - The Match rule is a convenient way to
+match artifacts (either in materials or products depending on where the rule is
+specified) with artifacts from other steps in the supply chain, allowing owners
+to establish a flow of artifacts between steps in the software supply chain.
+The proposal in this ITE would not affect the current functioning of the Match
+rule as the verification workflow only works with the prefixes and patterns, and
+isn't affected by what they directly represent - in the filesystem or otherwise.
+- `ALLOW <pattern>` - The Allow rule specifies an artifact matched by the rule
+is allowed as a material or product of the particular step. This rule is not
+affected by this ITE.
+- `DISALLOW <pattern>` - The Disallow rule specifies an artifact matched by the
+Rule is not allowed as a material or product of the particular step. This rule
+is not affected by this ITE.
+- `CREATE <pattern>` - The Create rule specifies that an artifact matched by
+this rule must not appear as a material of the particular step - it must instead
+be created as part of executing this step of the supply chain. This rule is not
+affected by this ITE.
+- `DELETE <pattern>` - The Delete rule specifies that an artifact matched by
+this rule must not appear as a product of the particular step - it must instead
+be deleted as part of executing this step of the supply chain. This rule is not
+affected by this ITE.
+- `REQUIRE <pattern>` - The Require rule specifies that an artifact matched by
+this rule must appear as a material or product of the particular step. This rule
+is not affected by this ITE.
+- `MODIFY <pattern>` - The Modify rule specifies that an artifact matched by
+this rule must appear as both a material and product of the step, and the hash
+of the artifact must differ indicating the execution of the step changed the
+artifact.
+
+[[motivation]]
+== Motivation
+
+ITE 4 is motivated by the following use cases.
+
+==== Use Case 1: SPDX License Identifiers
+
+The Software Package Data Exchange (SPDX) specification allows developers and
+maintainers to tag their packages with a specific license, which allows them to
+easily communicate the licensing information to all stakeholders of the package.
+By allowing generic URI schemes in in-toto, we can then allow developers to tag
+their in-toto metadata with an SPDX identifier.
+
+==== Use Case 2: GitHub Entities
+
+GitHub has more abstract entities such as Pull Requests and Issues. These
+entities can be referred to directly using the URI schemes proposed in this ITE
+and help provide attestations about this data.
+
+[[reasoning]]
+== Reasoning
+
+The changes proposed in this ITE allow for additional support for abstract
+entities as highlighted in the motivation section above. The in-toto
+specification primarily emphasizes how the verification workflow for in-toto
+metadata works, while briefly indicating how inspections must be executed. The
+inspection execution workflow is impacted as the tooling must be aware of how
+to resolve the URI tokens. A non conformant in-toto verification implementation
+can still verify if the link and layout metadata match, but will be unable to
+perform inspections if they involve abstract entities.
+
+[[backwards-compatibility]]
+== Backwards Compatibility
+
+If an implementation of in-toto does not conform to this ITE, there will be no
+backward incompatibility. It will, however, be incapable of handling metadata
+that was generated using an implementation conformant to this ITE.
+
+[[security]]
+== Security
+
+For the most part, the changes this ITE proposes don't affect the security
+guarantees made by the in-toto specification. The verification workflow is
+mostly unaffected by the changes in the metadata that conform to this ITE. A
+point of concern that needs to be further established or checked is the
+execution of commands for inspections and how they interact with non filesystem
+entities.
+
+[[infrastructure-requirements]]
+== Infrastructure Requirements
+
+There may be infrastructure costs involved in creating and maintaining a set of
+whitelisted URI tokens and their resolvers. This can also grow into a full
+fledged databse of approved or blessed resolvers that in-toto supports.
+
+[[testing]]
+== Testing
+
+If your implementation includes code, include this section describing how your
+changes will be tested.
+
+This ITE currently proposes no code changes.
+
+[[prototype-implementation]]
+== Prototype Implementation
+
+This ITE currently proposes no prototypes.
+
+[[references]]
+== References
+
+* link:https://tools.ietf.org/html/rfc3986[Uniform Resource Identifier (URI): Generic Syntax]
+* link:https://github.com/in-toto/docs/blob/master/in-toto-spec.md[in-toto Specification]

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -407,7 +407,9 @@ compliant in-toto tools to handle the resolving of generic URIs to these
 abstract resources securely. It is quite possible that the contents of these
 resources need to be serialized in some manner that allows for their hashing,
 and these operations when performed unsafely can lead to severe vulnerabilities
-if the resource is controlled by a malicious actor.
+if the resource is controlled by a malicious actor. Implementors must also take
+care to ensure they handle situations where a resource may be unavailable, and
+fail appropriately.
 
 Further, it is likely that abstract resources change more frequently, both in
 content and format, and implementors must take care to identify how these

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -150,8 +150,8 @@ follow.
 
 in-toto artifact rules are a means to specify what artifacts the project owner
 expects in every step of the supply chain in the in-toto layout. in-toto
-provides the certain rules that together attempt to describe the different types
-of operations or actions that supply chain functionaries carry out.
+provides certain rules that together attempt to describe the different types of
+operations or actions that supply chain functionaries carry out.
 
 *MATCH Rule*
 
@@ -393,10 +393,10 @@ with artifacts is to record their hashes using one or more cryptographic hash
 algorithms. Other artifact operations such as verifying the artifact rules
 rely on the hashes recorded in the link metadata.
 
-We found that the extending the recording of hashes to abstract resources, some
-of which may live at remote locations, is more complicated than the recording of
-hashes of artifacts in the local filesystem. It is, therefore, important for
-ITE-4 compliant in-toto tools to handle the resolving of generic URIs to these
+We found that the recording of hashes of abstract resources, some of which may
+live at remote locations, is more complicated than the recording of hashes of
+artifacts in the local filesystem. It is, therefore, important for ITE-4
+compliant in-toto tools to handle the resolving of generic URIs to these
 abstract resources securely. It is quite possible that the contents of these
 resources need to be serialized in some manner that allows for their hashing,
 and these operations when performed unsafely can lead to severe vulnerabilities

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -186,6 +186,80 @@ check that the provided pattern exists are does not exist in the relevant link
 metadata, without ever resolving the pattern into the artifact itself.
 Therefore, this ITE does not affect the working of these rules.
 
+[[example-uses]]
+== Example Uses
+
+==== GitHub: Attestations for merging a pull request into `master`
+
+A pull request is a proposal to make changes to a repository. Changes are either
+made on a separate branch on the same repository or a branch on a fork of the
+repository and the pull request is a proposal to merge these changes into the
+main repository. The act of merging a pull request is performed by an authorized
+member of the development team of the repository.
+
+By default, the commits that make up the change are integrated into the target
+branch and an additional merge commit is created to indicate the act of merging.
+It's also possible to merge a pull request without creating a separate merge
+commit. The attestation could look something like:
+
+```
+{
+    "_type": "link",
+    "name": "merge-pull-request-250",
+    "command": "<COMMAND>",
+    "materials": {
+        "github+https://github.com/in-toto/in-toto/pull/250": <HASH>
+    },
+    "products": {
+        "github+https://github.com/in-toto/in-toto/commit/f1c5d201887e226cadac5792a203ac3eae347add": <HASH>
+    },
+    "byproducts": {
+        "stderr": "",
+        "stdout": "",
+        "return-value": ""
+    },
+    "environment": {
+        "variables": "",
+        "filesystem": "",
+        "workdir": ""
+    }
+}
+```
+
+This step is accepting the pull request as a material and is recording the merge
+commit as a product.
+
+==== GitHub: Attestations for GitHub Actions building from a merge commit
+
+GitHub Actions can be used to set up a workflow for continuous integration (CI).
+Workflows can be triggered on push and an attestation can be generated for the
+build that as a result.
+
+
+```
+{
+    "_type": "link",
+    "name": "github-actions-build-pull-request-250",
+    "command": "<COMMAND>",
+    "materials": {
+        "github+https://github.com/in-toto/in-toto/commit/f1c5d201887e226cadac5792a203ac3eae347add": <HASH>
+    },
+    "products": {
+        "github+https://github.com/in-toto/in-toto/commit/f1c5d201887e226cadac5792a203ac3eae347add/checks?check_suite_id=<ID>": <HASH>
+    },
+    "byproducts": {
+        "stderr": "",
+        "stdout": "",
+        "return-value": ""
+    },
+    "environment": {
+        "variables": "",
+        "filesystem": "",
+        "workdir": ""
+    }
+}
+```
+
 [[reasoning]]
 == Reasoning
 

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -364,6 +364,42 @@ resulting build and CI report.
 }
 ```
 
+==== Use Case 3: Granular JSON Access
+
+The enhancement proposed in this ITE can also be used to provide more granular
+access to certain resources like JSON files. A generic URI can be used to
+resolve to the information contained in a specific key of the JSON. This allows
+for greater flexibility when using in-toto with different types of artifacts.
+
+===== in-toto link attestation signing contents of a specific JSON key
+
+An in-toto attestation can be generated when performing some operation over a
+single field in a JSON file, such as signing the contents of the field.
+
+```
+{
+    "_type": "link",
+    "name": "sign-json-key-testkey",
+    "command": "",
+    "materials": {
+        "json+file://test.json$testkey": <HASH>
+    },
+    "products": {
+        "json+file://test.json$testkey": <HASH>
+    },
+    "byproducts": {
+        "stderr": "",
+        "stdout": "",
+        "return-value": ""
+    },
+    "environment": {
+        "variables": "",
+        "filesystem": "",
+        "workdir": ""
+    }
+}
+```
+
 [[reasoning]]
 == Reasoning
 

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -163,10 +163,11 @@ github+https://github.com/in-toto/in-toto-golang/pull/ FROM merge-go-repository`
 *Other artifact rules*
 
 in-toto provides several other artifact rules - specifically `ALLOW`,
-`DISALLOW`, `CREATE`, `DELETE`, `REQUIRE`, and `MODIFY`. All these rules merely
-check that the provided pattern exists are does not exist in the relevant link
-metadata, without ever resolving the pattern into the artifact itself.
-Therefore, this ITE does not affect the working of these rules.
+`DISALLOW`, `CREATE`, `DELETE`, `REQUIRE`, and `MODIFY`. These rules perform
+different checks by verifying if artifacts matching the pattern occur or do not
+occur in the materials or products sections of the relevant link. This does not
+involve resolving the pattern or URI into the artifact itself, and so this ITE
+does not affect the working of these rules.
 
 [[motivation]]
 == Motivation

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -144,7 +144,14 @@ contain all the information necessary to identify the entity in that context.
 It is important to note that this ITE doesn't mandate any specific generic URI
 tokens that all conforming implementations MUST support. Instead, it merely
 specifies what any generic URI MUST look like, and what rules the system MUST
-follow.
+follow. However, it is vital to create a formal process that introduces new URI
+tokens and details how their abstract contents are hashed. This ensures that
+different in-toto implementations do not diverge significantly, and by creating
+an open process that involves the in-toto community, it can ensure consistency
+when hashing resources that multiple stakeholders use. Finally, such a process
+will also help ensure that the hashing of these entities is done in a correct
+and secure manner. However, detailing such a process is out of the scope of this
+ITE and must instead be handled in a future ITE.
 
 ==== Artifact Rules
 

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -39,11 +39,17 @@ endif::[]
 This ITE proposes a generic Unique Resource Identifier (URI) scheme for in-toto
 artifacts. Currently, the in-toto specification only allows for files in the
 local filesystem to be the artifacts of link metadata. This ITE also defines the
-scheme for a generic URI and analyzes the impact of intriducing generic URIs on
-the larger in-toto specification.
+scheme for a generic URI and provides a behaviour of in-toto implementations
+that support generic URIs.
 
 [[specification]]
 == Specification
+
+The current in-toto specification must be modified to provide support for the
+generic URI schemes. The current specification allows only for files in the
+local filesystem to be set as artifacts. With the addition of other entities,
+the parts of the specification that directly interact or handle the artifacts
+must be updated.
 
 in-toto link metadata files currently look like this:
 
@@ -76,97 +82,129 @@ in-toto link metadata files currently look like this:
 The `materials` and `products` fields contain key-value pairs. The URI for each
 artifact is its path in the filesystem. With this ITE active, the artifact could
 instead have a generic URI which can be resolved to some external resource that
-is part of the supply chain. The URI must have a fixed structure and must
+is part of the supply chain. The URI MUST have a fixed structure and MUST
 contain all the information necessary for any verifier to obtain the resource it
-refers to. Therefore, any verifier must be able to take the URI in isolation and
+refers to. Therefore, any verifier MUST be able to take the URI in isolation and
 know how and where to find the artifact.
 
 This ITE proposes the following structure for the URI.
 
-`<URI Identifier/Token>+<Transport Protocol>://<Location>`
+`<scheme>:<hier-part>`
 
-The URI Identifier must be unique and the verifier must know how to resolve all
-relevant identifiers. Let's take the example of a GitHub specific artifact. If
-the artifact is a pull request, the URI could be as simple as:
+This structure is derived from RFC 3986. The `scheme` defines the token or
+identifier for the type of resource the URI refers to . It can also contain
+other relevant information that indicates how the resource can be accessed. The
+`hier-part` identifies the path or location of the resource.
+
+A compliant in-toto system must be capable of generating link metadata with
+artifacts that have generic URI references. Therefore, this system must also be
+capable of resolving this URI and calculating cryptographic hashes of these
+artifacts. It's important to note that the contents of the resource are hashed,
+as opposed to the URI itself.
+
+To that end, it's important for a URI scheme to have a single mapping for the
+service it refers to. Consider an example of a GitHub specific resource - a pull
+request or an issue.
 
 `github+https://github.com/in-toto/in-toto/pull/250`
 
-Inspections are carried out during the verification workflow but essentially
-make use of the in-toto run workflow. Therefore, the system must know how to
-resolve these URIs and appropriately record them in the link metadata generated
-for the inspection. To that end, a resolver must be capable of:
+This can also instead use GitHub's API specific URI to refer to the same data.
 
-- `compute_hash` - This operation must know how to use the transport and
-location specified in the URI to serialize the target artifact and compute its
-hash. The implementation of this is very specific to each individual type of
-entity.
+`github+https://api.github.com/repos/in-toto/in-toto/pulls/250`
 
-The above operations can be expanded to fetch SPDX licenses and entire
-documents. An SPDX license URI can be used to directly fetch the corresponding
-license file from the SPDX website. On the other hand, SPDX documents must be
-fetched from wherever the document publisher has made it available, and the
-verification process should validate if the document matches a particular
-version of the SPDX specification. These are implementation specific details.
+The in-toto system generating link metadata for this artifact MUST be capable
+of recognizing that it possesses a generic URI, and the system MUST be able to
+resolve this resource and compute its cryptographic hash information. 
 
-This ITE doesn't limit the available operations - it merely specifies the
-mandatory operations a resolver must provide to allow all conforming in-toto
-verification implementations to be able to verify metadata. Additional methods
-can be provided which custom in-toto implementations can use for their specific
-purposes.
+An example of the product field for link metadata with a generic URI is as
+follows:
 
-==== Implications for the existing in-toto specification
+```
+"products": {
+    "github+https://api.github.com/repos/in-toto/in-toto/pulls/250": {
+        "sha256": "7ee0617..."
+    },
+    "...": ...
+}
+```
 
-The current in-toto specification must be modified to provide support for the
-generic URI schemes. The current specification allows only for files in the
-local filesystem to be set as artifacts. With the addition of other entities,
-the parts of the specification that directly interact or handle the artifacts
-must be updated.
+Similarly, an SPDX URI can be used to directly fetch the corresponding documents
+from a specified location. For in-toto metadata that exist within SPDX
+documents, the URI can also be used to refer to other entities elsewhere in the
+document.
 
 Artifact Rules are a means to specify what artifacts the project owner expects
-in every step of the supply chain. Here is the analysis of the impact on each:
+in every step of the supply chain in the in-toto layout. in-toto povides the
+following rules that together attempt to describe the different types of
+operations or actions that supply chain functionaries carry out.
 
-- `MATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS) [IN
-<destination-path-prefix>] FROM <step>` - The Match rule is a convenient way to
-match artifacts (either in materials or products depending on where the rule is
-specified) with artifacts from other steps in the supply chain, allowing owners
-to establish a flow of artifacts between steps in the software supply chain.
-The proposal in this ITE would not affect the current functioning of the Match
-rule as the verification workflow only works with the prefixes and patterns, and
-isn't affected by what they directly represent - in the filesystem or otherwise.
-- `ALLOW <pattern>` - The Allow rule specifies an artifact matched by the rule
-is allowed as a material or product of the particular step. This rule is not
-affected by this ITE.
-- `DISALLOW <pattern>` - The Disallow rule specifies an artifact matched by the
-Rule is not allowed as a material or product of the particular step. This rule
-is not affected by this ITE.
-- `CREATE <pattern>` - The Create rule specifies that an artifact matched by
-this rule must not appear as a material of the particular step - it must instead
-be created as part of executing this step of the supply chain. This rule is not
-affected by this ITE.
-- `DELETE <pattern>` - The Delete rule specifies that an artifact matched by
-this rule must not appear as a product of the particular step - it must instead
-be deleted as part of executing this step of the supply chain. This rule is not
-affected by this ITE.
-- `REQUIRE <pattern>` - The Require rule specifies that an artifact matched by
-this rule must appear as a material or product of the particular step. This rule
-is not affected by this ITE.
-- `MODIFY <pattern>` - The Modify rule specifies that an artifact matched by
-this rule must appear as both a material and product of the step, and the hash
-of the artifact must differ indicating the execution of the step changed the
-artifact.
+=== `MATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS) [IN <destination-path-prefix>] FROM <step>`
+
+The Match rule is a convenient way to match artifacts (either in materials or
+products depending on where the rule is specified) with artifacts from other
+steps in the supply chain, allowing owners to establish a flow of artifacts
+between steps in the software supply chain.
+
+The current verification workflow for the `MATCH` rule compares the
+cryptographic hashes of the relevant artifacts from the respective link files.
+This is a straightforward comparison and does not entail resolving the URIs in
+any form. The `IN` clauses which are used to specify path prefixes are
+subtracted from the URI strings. Therefore, we conclude that the functioning of
+the rule doesn't change with this ITE. An example `MATCH` rule with generic URIs
+is as follows:
+
+`MATCH pull/250 IN github+https://github.com/in-toto/in-toto/ WITH PRODUCTS IN
+github+https://github.com/in-toto/in-toto-golang/pull/ FROM merge-go-repository`
+
+=== `ALLOW <pattern>`
+
+The Allow rule specifies an artifact matched by the rule is allowed as a
+material or product of the particular step. This rule is not affected by this
+ITE.
+
+=== `DISALLOW <pattern>`
+
+The Disallow rule specifies an artifact matched by the Rule is not allowed as a
+material or product of the particular step. This rule is not affected by this
+ITE.
+
+=== `CREATE <pattern>`
+
+The Create rule specifies that an artifact matched by this rule MUST not appear
+as a material of the particular step - it MUST instead be created as part of
+executing this step of the supply chain. This rule is not affected by this ITE.
+
+=== `DELETE <pattern>`
+
+The Delete rule specifies that an artifact matched by this rule MUST not appear
+as a product of the particular step - it MUST instead be deleted as part of
+executing this step of the supply chain. This rule is not affected by this ITE.
+
+=== `REQUIRE <pattern>`
+
+The Require rule specifies that an artifact matched by this rule MUST appear as
+a material or product of the particular step. This rule is not affected by this
+ITE.
+
+=== `MODIFY <pattern>`
+
+The Modify rule specifies that an artifact matched by this rule MUST appear as
+both a material and product of the step, and the hash of the artifact MUST
+differ indicating the execution of the step changed the artifact.
 
 [[motivation]]
 == Motivation
 
 ITE 4 is motivated by the following use cases.
 
-==== Use Case 1: SPDX License Identifiers
+==== Use Case 1: SPDX Document Identifiers
 
-The Software Package Data Exchange (SPDX) specification allows developers and
-maintainers to tag their packages with a specific license, which allows them to
-easily communicate the licensing information to all stakeholders of the package.
-By allowing generic URI schemes in in-toto, we can then allow developers to tag
-their in-toto metadata with an SPDX identifier.
+The Software Package Data Exchange (SPDX) is an open standard for communicating
+software bill of material information such as components, licenses, copyrights,
+and security references. Each document is a comprehensive report that describes
+a software package in detail. They're composed of several entities that have
+unique identifiers. These identifiers can be used in in-toto metadata embedded
+in SPDX documents to refer to the respective entities.
 
 ==== Use Case 2: GitHub Entities
 
@@ -177,46 +215,56 @@ and help provide attestations about this data.
 [[reasoning]]
 == Reasoning
 
-The changes proposed in this ITE allow for additional support for abstract
-entities as highlighted in the motivation section above. The in-toto
-specification primarily emphasizes how the verification workflow for in-toto
-metadata works, while briefly indicating how inspections must be executed. The
-inspection execution workflow is impacted as the tooling must be aware of how
-to resolve the URI tokens. A non conformant in-toto verification implementation
-can still verify if the link and layout metadata match, but will be unable to
-perform inspections if they involve abstract entities.
+This ITE proposes a change in the URI scheme of artifacts in in-toto metadata.
+The proposed change closely matches the URI structure laid out in RFC 3986. The
+URI structure propsed in that document is widely accepted and is versatile
+enough to allow for a wide variety of references. It is also easy to implement
+and extend support for due to the presence of a large number of standard
+libraries.
 
 [[backwards-compatibility]]
 == Backwards Compatibility
 
-If an implementation of in-toto does not conform to this ITE, there will be no
-backward incompatibility. It will, however, be incapable of handling metadata
-that was generated using an implementation conformant to this ITE.
+If in-toto metadata is generated using an implementation of in-toto conforming
+to this ITE, verification using a non-conforming implementation will likely
+fail. It is still possible for verification to continue if the inspections don't
+use generic URIs.
+
+However, a conforming implementation should be capable of verifying in-toto
+metadata generated using a non-conforming implementation, as a conforming
+system must also conform to the main in-toto specification.
+
+It's also possible two conforming systems are unable to verify the other's
+in-toto metadata as they're unaware of how to resolve certain URI tokens used by
+the other.
 
 [[security]]
 == Security
 
-For the most part, the changes this ITE proposes don't affect the security
-guarantees made by the in-toto specification. The verification workflow is
-mostly unaffected by the changes in the metadata that conform to this ITE. A
-point of concern that needs to be further established or checked is the
-execution of commands for inspections and how they interact with non filesystem
-entities.
+It's important to note that filepaths are a form of URIs too, and can be
+represented with the `scheme` `file://`. We have also discovered that `MATCH`
+and other artifact rules use only the URI strings themselves to find the
+appropriate entries in the link metadata. The changes proposed in this ITE,
+therefore, have no effect on the security guarantees made by th in-toto
+specification.
+
+Implementing systems that conform to this ITE must, however, be careful with how
+they compute cryptographic hashes of abstract entities.
 
 [[infrastructure-requirements]]
 == Infrastructure Requirements
 
-There may be infrastructure costs involved in creating and maintaining a set of
-whitelisted URI tokens and their resolvers. This can also grow into a full
-fledged databse of approved or blessed resolvers that in-toto supports.
+This ITE proposes no infrastructure changes.
 
 [[testing]]
 == Testing
 
-If your implementation includes code, include this section describing how your
-changes will be tested.
+In an in-toto system conforming to this ITE, it is important to test:
 
-This ITE currently proposes no code changes.
+- that all the artifact rules behave as described in the specification
+- that cryptographic hashes of data in abstract entities change with changes in
+in the data - in effect, this would test how the data is transformed into a form
+that can be hashed
 
 [[prototype-implementation]]
 == Prototype Implementation
@@ -228,3 +276,4 @@ This ITE currently proposes no prototypes.
 
 * link:https://tools.ietf.org/html/rfc3986[Uniform Resource Identifier (URI): Generic Syntax]
 * link:https://github.com/in-toto/docs/blob/master/in-toto-spec.md[in-toto Specification]
+* link:https://pypi.org/project/rfc3986/[RFC 3986 library for Python]

--- a/ITE/4/README.adoc
+++ b/ITE/4/README.adoc
@@ -220,7 +220,7 @@ GitHub has more abstract entities such as Pull Requests and Issues. These
 entities can be referred to directly using the URI schemes proposed in this ITE
 and help provide attestations about these artifacts. Consider:
 
-===== in-toto link attestations for merging a pull request into `master`
+===== in-toto link attestation for merging a pull request into `master`
 
 A pull request is a proposal to make changes to a repository. Changes are either
 made on a separate branch on the same repository or a branch on a fork of the
@@ -260,7 +260,7 @@ commit. The attestation could look something like:
 This step is accepting the pull request as a material and is recording the merge
 commit as a product.
 
-===== in-toto link attesations for GitHub Actions building from a merge commit
+===== in-toto link attesation for GitHub Actions building from a merge commit
 
 GitHub Actions can be used to set up a workflow for continuous integration (CI).
 Workflows can be triggered on push and an attestation can be generated for the


### PR DESCRIPTION
This ITE proposes allowing generic URI schemes to refer to abstract entities in in-toto metadata.