### PR TITLE
Add ITE-10 adding policy definitions in layouts for in-toto attestations

### DIFF
--- a/ITE/10/README.adoc
+++ b/ITE/10/README.adoc
@@ -164,7 +164,7 @@ apply to attestation subjects.
 
 ```yaml
 subject: string
-expectedPredicates: list of ExpectedSubectPredicates
+expectedPredicates: list of ExpectedSubjectPredicates
 ```
 
 The `subject` can be a pattern that is applied against all attestations in the

--- a/ITE/10/README.adoc
+++ b/ITE/10/README.adoc
@@ -37,7 +37,7 @@ endif::[]
 == Abstract
 
 A previous in-toto Enhancement, ITE-6, presented the in-toto Attestation
-framework. This framework introduced the idea of context-specific attestations
+Framework. This framework introduced the idea of context-specific attestations
 with their own definitions. This ITE builds on ITE-6 and proposes several
 modifications to in-toto layouts that allow for defining and verifying policies
 over ITE-6 attestations.
@@ -45,11 +45,9 @@ over ITE-6 attestations.
 [[specification]]
 == Specification
 
-=== Changes to Metadata Schema
-
 The in-toto specification describes the following schema for layouts.
 
-```
+```json
 {
     "_type": "layout",
     "expires": "<EXPIRES>",
@@ -62,16 +60,32 @@ The in-toto specification describes the following schema for layouts.
 }
 ```
 
-As a whole, in-toto breaks down every software supply chain into a number of
-steps. The specification's verification workflow uses in-toto link metadata for
-each step to ensure it was performed correctly. Each step has the following
-schema.
+An in-toto layout provides two semantics for software supply chain owners to
+define policies: steps and inspections. Steps are used to reason about and
+express constraints regarding operations _already_ performed as part of the
+supply chain. The verification is focused on ensuring authorized functionaries
+performed each step and validating the integrity of artifacts as they move from
+one step to the next. Inspections are executed _during_ verification to perform
+any other checks that are defined as external scripts.
 
-```
+TODO: this pass does not revise artifact rules for steps.
+
+This ITE primarily updates the schema and capabilities for inspections. As it
+stands, the inspections semantic can already be used to apply arbitrary
+constraints to data captured in in-toto links. Similarly, they can apply
+constraints to attestations as well. We update in-toto inspections with more
+capabilities so that they do not necessarily have to be executed as separate
+scripts. This is achieved by providing multiple options for the domain specific
+language used to express constraints. Currently, inspections only support using
+in-toto's artifact rules. With this ITE, this will remain an option, but
+inspections can also be written to not execute separate shell scripts and use
+artifact rules, and instead express data constraints using DSLs like Rego or
+Cue. The current inspection schema is as follows:
+
+```json
 {
-    "_type": "step",
+    "_type": "inspection",
     "name": "<NAME>",
-    "threshold": "<THRESHOLD>",
     "expected_materials": [
         [ "<ARTIFACT_RULE>" ],
         "..."
@@ -80,157 +94,114 @@ schema.
         [ "<ARTIFACT_RULE>" ],
         "..."
     ],
-    "pubkeys": ["<KEYID>", "..."],
-    "expected_command": "<COMMAND>"
-}
-```
-
-This ITE proposes modifying the step object to account for different types of
-rules. First, artifact rules recorded for `expected_materials` and
-`expected_products` are collected within a single field called
-`expected_artifacts`. These rules can be verified against in-toto link
-attestations or equivalent attestations accepted via ITE-9 such as SLSA
-Provenance. Second, this ITE adds an `expected_properties` field. Every entry in
-this field is expected to be some property a valid execution of the step is
-expected to possess, and the updated in-toto verification workflow passes only
-if the attestations presented can be validated as meeting every property. The
-updated step definition has the following schema.
-
-```
-{
-    "_type": "step",
-    "name": "<NAME>",
-    "expected_artifacts": {
-        "threshold": "<THRESHOLD>",
-        "pubkeys": ["<KEYID>", "..."],
-        "materials": [
-            [ "<ARTIFACT_RULE>" ],
-            "..."
-        ],
-        "products": [
-            [ "<ARTIFACT_RULE>" ],
-            "..."
-        ]
-    },
-    "expected_properties": {
-        "<PROPERTY_NAME>": {
-            "pubkeys": ["<KEYID>", "..."],
-            "threshold": "<THRESHOLD>"
-        }
-    },
-    "expected_command": "<COMMAND>"
-}
-```
-
-Similarly, each in-toto inspection object is updated to allow for properties. As
-inspections are run during verification, there is no expectation for authorized
-`pubkeys` or `threshold`. As such, the `expected_properties` field is just a
-list of property names.
-
-```
-{
-    "_type": "step",
-    "name": "<NAME>",
-    "expected_artifacts": {
-        "materials": [
-            [ "<ARTIFACT_RULE>" ],
-            "..."
-        ],
-        "products": [
-            [ "<ARTIFACT_RULE>" ],
-            "..."
-        ]
-    },
-    "expected_properties": ["<PROPERTY_NAME>", "..."],
     "run": "<COMMAND>"
 }
 ```
 
-NOTE: Do we consider replacing artifact rules altogether?
+The above schema can also be expressed using the following generalization that
+allows for multiple DSLs. Note that several fields are optional.
 
-The rules for each property validation are recorded in a new field in the
-layout, outside of the step definitions. These definitions can thus be reused
-across steps in the software supply chain.
 
-NOTE: We should evaluate inline policy definitions / extensions.
-
-Additionally, software supply chain owners can define policies for properties
-that apply to the supply chain as a whole rather than any one step. In some
-cases, these properties may apply to two or more steps. Therefore, the updated
-layout schema also supports `expected_properties` at the layout-wide level.
-Aside from the standard `pubkeys` and `threshold` fields, it also includes a
-`steps` field. During verification of a layout-wide policy, attestations from
-the listed steps are made available to it. The `steps` field is optional and
-these properties can also be satisfied with layout-specific attestations rather
-than step-specific attestations. All layout-specific attestations are made
-available to every property listed here, even if the `steps` field is used.
-
-```
+```json
 {
-    "_type": "layout",
-    "expires": "<EXPIRES>",
-    "readme: "<README>",
-    "keys": {
-        "<KEYID>": "<PUBKEY_OBJECT>"
-    },
-    "properties": {
-        "<PROPERTY_NAME>": {
-            "accepted_attestation_types": ["<PREDICATE_TYPE>", ...]
-            "policy_language": "<POLICY_LANGUAGE>", // FIXME: see NOTE about supporting multiple languages
-            "policy": "<POLICY>"
-        }
-    }
-    "expected_properties": {
-        "<PROPERTY_NAME>": {
-            "steps": ["<STEP_NAME>", "..."],
-            "pubkeys": ["<KEYID>", "..."],
-            "threshold": "<THRESHOLD>"
-        }
-    }
-    "steps": ["<STEP>", "..."],
-    "inspect": ["<INSPECTION>", "..."]
+    "_type": "inspection",
+    "name": "<NAME>",
+    "functionaries": ["<KEYID>", "..."],
+    "threshold": "<THRESHOLD>",
+    "subject": ["<SUBJECT>", "..."],
+    "policyLanguage": "<POLICY_LANGUAGE>",
+    "policy": "<POLICY>",
+    "run": "<COMMAND>"
 }
 ```
 
-All ITE-6 attestations have a `PREDICATE_TYPE` identifying the type of
-predicate. For each property, software supply chain owners can specify a list of
-acceptable predicates that can be used to meet the policy. The use of `<POLICY>`
-and `<POLICY_LANGUAGE>` are elaborated in a standalone section.
+Currently supported inspections _always_ execute a command or script and
+generate link metadata. As this is during verification, they are not signed. As
+such, to support the current model, `functionaries` and `threshold` are
+optional. Similarly, `subject` is also unnecessary. `policyLanguage` is used to
+indicate the policy is expressed as in-toto artifact rules and `policy` contains
+the actual rules currently expressed as `expected_materials` and
+`expected_products`.
 
-=== Specifying Policies for Properties
+However, this model provides a lot of flexibility when it comes to other DSLs.
+Consider the following subset of the block above:
 
-This ITE proposes the use of existing policy definition languages such as Rego
-and CUE. Note that embedding the policies themselves can be complicated by the
-wireline format used by a particular in-toto implementation. In general,
-`POLICY_LANGUAGE` must unambiguously identify the language and the `POLICY`
-must contain the policy itself in the specified language. For example, if an
-implementation uses some flavor of JSON for its metadata, the policy may be
-Base64 encoded and then stored in the layout.
+```json
+{
+    "_type": "inspection",
+    "name": "<NAME>",
+    "functionaries": ["<KEYID>", "..."],
+    "threshold": "<THRESHOLD>",
+    "subject": ["<SUBJECT>", "..."],
+    "policyLanguage": "<POLICY_LANGUAGE>",
+    "policy": "<POLICY>",
+}
+```
 
-NOTE: FIXME, we need a separate evaluation of policy languages, and we should
-decide if we pick a winner / allow for multiple.
+Only `run` is removed as in this example, an external command or script is not
+invoked. Instead, the `policyLanguage` used is a logic programming language and
+the `policy` expresses directly the checks that previously needed to be a
+separate script. Here, `subject` is used to identify the sets of attestations
+the policy is applied against. Further, the `functionaries` and `threshold`
+fields can be used to directly check the source of the claims being verified by
+the policy. In the current model, as inspections reason about link metadata
+generated for the execution of the inspection itself, any inspection that
+used a script to check contents of link metadata from some prior step also
+needed to verify the functionary signing the metadata in the script--in-toto's
+semantics are not used directly.
 
-TODO: if we are not picking one or more winners, we should enumerate the
-properties of acceptable policy languages. However, I'm leaning towards picking
-winners and expanding them with future ITEs if necessary.
+TODO: the last bit of the paragraph is very convoluted. What I'm trying to say
+is that inspection scripts must also reason about and verify any prior metadata
+they're looking at is signed by the right keys, with the right threshold, and so
+on. They cannot just verify the claims themselves. This is important because:
+1. you may have link metadata that was signed by the wrong functionary, rejected
+   during verification of the step, but the threshold was still met. Claims made
+   by this metadata shouldn't be trusted by inspections.
+2. you may have link metadata with differing attributes for the same step by
+   design. One example: reproducible builds with one piece of metadata generated
+   by an isolated environment. The inspection here should be able to reason
+   about which metadata has these claims and if it's from the right environment.
 
-NOTE: FIXME, is there a better way to do this? Detached policies?
+Note that a policy specified in an inspection block is not applied to some
+specified set of attestation types. Policies apply to _subjects_ of the supply
+chain, whether artifacts or other processes captured using ITE-4 semantics.
+During the verification workflow, all attestations are parsed to represent their
+claims in the context of the subjects they apply to. So, all available
+information for a subject is available along with the functionaries signing for
+each individual claim, and this representation of attestation claims is used to
+apply policies. Attestations must not be parsed if their signatures cannot be
+verified using functionary information available in the layout.
 
-=== Validating Policies for a Step
+=== Specifying Policies
 
-The in-toto verification workflow specified in the specification is updated to
-include the verification of policies for expected properties of each step.
-Specifically, alongside link metadata, the verification workflow looks must be
-presented with attestations of the types allowed for a particular property,
-defined in the `accepted_attestation_types` field.
+In general, each unit policy applies one constraint. For example, a policy might
+mirror in-toto's artifact rules, ensuring that all the materials and products of
+some step in the supply chain are as expected. Alternatively, a policy can apply
+a property-oriented constraint to an artifact or step, such as validating the
+Provenance of an artifact or that its build process was performed in an isolated
+and hermetic build environment. Note that all of these types of policies can
+coexist and successful verification is contingent on all policy validations
+succeeding.
 
-Every attestation that is loaded has its signatures validated to ensure the
-metadata was generated by authorized keys (and by extension, functionaries).
-Next, the `POLICY` for each property is executed against the loaded
-attestations. If the policy executes to `true`, the property is deemed to be
-verified and the workflow moves on to the next property.
+This indicates that developers need a great deal of flexibility in specifying
+policies _and_ that any domain-specific language chosen or created to express
+policies must have the necessary capabilities to fit these requirements.
 
-TODO: Include examples of policies evaluating to `true` for some property.
+Prior literature has explored the use of logic based languages and their
+derivatives for specifying and validating policies. Policies, at their core, are
+logic programs that are applied against a set of claims, expressed here as
+in-toto attestations. This ITE uses languages such as Rego and CUE as examples
+of such languages, but leaves the specific choices to the in-toto community and
+adopters. The new layout schema proposed above includes a `<POLICY_LANGUAGE>`
+attribute for each policy to enable this variety in choice.
+
+=== Validating Policies
+
+The in-toto verification workflow is updated to support different types of
+inspections as defined in this ITE. For new style inspection blocks, the
+verification workflow uses the `policyLanguage` field to decide which policy
+engine to use. If `run` is specified, the workflow executes the command or
+script as it does now.
 
 [[motivation]]
 == Motivation
@@ -242,14 +213,8 @@ artifact rules, to verify the flow of artifacts in their supply chains. ITE-6
 expanded the metadata formats to support the generation of custom attestations
 that have context-specific schemas. Current in-toto layouts as defined in the
 in-toto specification cannot be used to verify the information contained in
-these attestations.
-
-This ITE partitions attestations into two categories. Attestations can contain
-information about the flow of artifacts, like in-toto link metadata, and they
-can contain information about other properties of the supply chain. As such, the
-proposed changes to the layout in this ITE allow supply chain owners to define
-artifact rules for the former and policies verifying the existence of desirable
-properties for the latter.
+these attestations without executing external scripts or commands, and cannot
+directly reason about the sources of claims made in them.
 
 [[reasoning]]
 == Reasoning
@@ -292,12 +257,12 @@ verification of that property is successful.
 [[backwards-compatibility]]
 == Backwards Compatibility
 
-This ITE significantly affects the backwards compatibility of in-toto metadata.
-For starters, the layout schema changes quite significantly. However, layouts
-that conform to the in-toto specification can be converted to the schema
-proposed here and therefore implementations conforming to this ITE can verify
-old layouts. On the other hand, old implementations cannot verify layouts
-conforming to this schema.
+All the capabilities currently enabled by in-toto inspections are retained in
+the changes proposed here. As such, there is no regression in capabilities.
+
+However, any new-style inspections as defined here cannot be verified by older
+in-toto implementations. Further, implementations must decide independently
+their timeline of support for the old-style inspection definitions.
 
 [[security]]
 == Security

--- a/ITE/10/README.adoc
+++ b/ITE/10/README.adoc
@@ -141,25 +141,6 @@ language: string
 rule: object
 ```
 
-=== Verification Workflow
-
-After verifying the layout and attestation signatures (including thresholds
-where applicable), attestations must be parsed to identify the materials and
-products of the step they represent. In link class predicates, the materials are
-found within the predicate and products are recorded as the attestation's
-subject. Note that alongside these artifacts, other predicate fields excluding
-the materials must also be parsed in as part of the products to enable policies
-on their contents. For attribute class predicates, the materials are the
-attestation's subject and products are exclusively the attributes recorded
-within the predicate.
-
-With this internal representation of all attestations created, each step's
-`expectedMaterial` policies are applied against the material artifacts. If an
-error is encountered, the verification workflow is terminated. Similarly, the
-policies recorded for `expectedProducts` are applied against product artifacts
-and finally, policies in `expectedAttributes` are applied against all other
-claims.
-
 === Role of Inspections
 
 Inspections are primarily used at verification time to examine the final 
@@ -197,6 +178,40 @@ subject: list of patterns
 predicates: list of TypeURIs
 expectedAttributes: list of constraints
 ```
+
+=== Verification Workflow
+
+As with the current in-toto specification, the verification workflow is
+presented with a root layout, public keys to verify the layout's signatures, and
+a bundle of in-toto attestations. The workflow, at a high level, can be
+described as follows:
+
+.   The layout's signatures are verified using the provided keys.
+.   The layout is parsed and its validity, i.e. the expiration date, is
+    checked.
+.   For each step in the layout, the corresponding attestations are loaded. The
+    attestations must match the expected predicate types. As each attestation
+    is loaded, its signatures are first verified against expected signers for
+    the step. Also, a threshold of attestations are loaded where specified.
+..  If the step specifies a sublayout, the verification workflow is recursively
+    applied against the corresponding layout.
+..  Else, after the attestations are loaded with corresponding mapping for
+    materials (and products if it's a link class attestation), the constraints
+    specified in `expectedMaterials`, `expectedProducts`, and
+    `expectedAttributes` are verified respectively.
+.   For each inspection:
+..  If the inspection expects a command run, the command is executed and a link
+    class attestation is generated. Then, the `expectedMaterials`,
+    `expectedProducts`, and `expectedAttributes` are applied against the
+    contents of the attestation.
+..  Else, the inspection applies against one or more subjects. The patterns
+    specified are against all subjects in every attestation in the bundle. The
+    attestations that match the patterns are parsed to extract their claims. If
+    the attestations signatures weren't verified already when verifying steps,
+    the signatures are verified now. Each claim is associated with the subject
+    it applies to, the predicate type of the claiming attestation, and the
+    functionary that signed the attestation. Finally, the `expectedAttributes`
+    constraints are applied against the collection of claims.
 
 [[motivation]]
 == Motivation

--- a/ITE/10/README.adoc
+++ b/ITE/10/README.adoc
@@ -342,10 +342,20 @@ their timeline of support for the old-style inspection definitions.
 [[security]]
 == Security
 
+This ITE does not significantly affect the security of in-toto layouts. It
+preserves all of the existing capabilities of layouts. That said, as the ITE
+allows for using externally created languages to write constraints executed at
+verification time, implementers of the ITE are urged to choose the languages
+they support carefully. Each language must be evaluated on a case-by-case basis
+to ensure it does not introduce undesirable capabilities such as the ability to
+execute arbitrary code into verification environments. Indeed, by allowing for
+such limited capability languages, the hope is to reduce in-toto's dependence
+on inspection scripts that have no such limitations.
 
 [[infrastructure-requirements]]
 == Infrastructure Requirements
 
+None.
 
 [[prototype-implementation]]
 == Prototype Implementation
@@ -355,6 +365,9 @@ None yet.
 [[testing]]
 == Testing
 
+Implementations of this layout schema and the accompanying verification
+workflow must be thoroughly tested to ensure their backwards compatibility with
+old layouts.
 
 [[references]]
 == References

--- a/ITE/10/README.adoc
+++ b/ITE/10/README.adoc
@@ -74,23 +74,23 @@ necessary to rework the layout to support verifying a variety of _predicates_.
 As the framework is designed to generate claims pertaining to how software is
 produced, each predicate type can be mapped to a step in the software supply
 chain. However, it is first necessary to understand the nature of each step, and
-therefore its predicate type. in-toto was originally designed with the
+therefore its predicate types. in-toto was originally designed with the
 assumption that a step in the software supply chain affects in some manner the
 artifacts that constitute the supply chain. ITE-6 showed that some steps do not
 fit the materials and products model. This is a factor in _verifying_ such
 predicates using in-toto layouts.
 
 Therefore, all predicates supported for verification in an in-toto layout must
-categorized as one of two types:
+categorized as one of two classes:
 
-* the link type: these are based on classic in-toto links for steps that affect
-  artifacts in some manner. They consume some artifacts as materials and produce
-  others as products. The subject of such attestations indicate the products of
-  the step. Eg. in-toto links, SLSA Provenance.
-* the attribute type: these predicates record contextual attributes about one or
-  more artifacts. The operations they represent consume artifacts as materials
-  (recorded as the subject of such attestations) and produce attributes about
-  them as the outcome. Eg. test results, reviews.
+* the link class: these are based on classic in-toto links for steps that
+  transform artifacts in some manner. They consume some artifacts as materials
+  and produce others as products. The subject of such attestations indicate the
+  products of the step. Eg. in-toto links, SLSA Provenance.
+* the attribute class: these predicates record contextual attributes about one
+  or more artifacts. The operations they represent consume artifacts as
+  materials (recorded as the subject of such attestations) and produce
+  attributes about them as the outcome. Eg. test results, reviews.
 
 Note that predicates that fit the first category may also record certain
 attributes. For example, the environment field in in-toto links can include such
@@ -145,18 +145,20 @@ rule: object
 
 After verifying the layout and attestation signatures (including thresholds
 where applicable), attestations must be parsed to identify the materials and
-products of the step they represent. In link type predicates, the materials are
+products of the step they represent. In link class predicates, the materials are
 found within the predicate and products are recorded as the attestation's
 subject. Note that alongside these artifacts, other predicate fields excluding
 the materials must also be parsed in as part of the products to enable policies
-on their contents.  For attribute type predicates, the materials are the
+on their contents. For attribute class predicates, the materials are the
 attestation's subject and products are exclusively the attributes recorded
 within the predicate.
 
 With this internal representation of all attestations created, each step's
-material policies are applied against the material artifacts. If an error is
-encountered, the verification workflow is terminated. If not, the workflow
-proceeds to the product policies.
+`expectedMaterial` policies are applied against the material artifacts. If an
+error is encountered, the verification workflow is terminated. Similarly, the
+policies recorded for `expectedProducts` are applied against product artifacts
+and finally, policies in `expectedAttributes` are applied against all other
+claims.
 
 === Role of Inspections
 
@@ -164,8 +166,9 @@ Inspections are primarily used at verification time to examine the final
 products and their in-toto metadata. They may be of two types. In the first,
 inspections largely function like they do in the current in-toto specification.
 They are used as a mechanism to execute custom checks during the verification
-workflow. Their materials and products fields are similarly enhanced with
-support for policy languages alongside in-toto artifact rules. By default,
+workflow. Their `expectedMaterials` and `expectedProducts` fields are similarly
+enhanced with support for policy languages alongside in-toto artifact rules, and
+they're joined by `expectedAttributes` like step definitions. By default,
 inspections are expected to generate in-toto links. However, the inspection
 declaration may specify an alternative predicate the check may result in.
 
@@ -181,10 +184,12 @@ expectedAttributes: list of constraints
 The second type of inspections do not execute a command or script to perform
 some check. Instead, they are used to apply constraints on the _subjects_ of
 in-toto attestations for a supply chain. Instead of `command`, the schema has a
-`subject` field that accepts one or more patterns. The claims from all
+`subject` field that accepts one or more patterns that are applied against the
+subjects of all attestations in the bundle being verified. The claims from all
 attestations part of the verification whose subjects match the specified
 patterns are collated. The inspection's constraints are then applied to the
-claims pertaining to the subjects.
+claims pertaining to the subjects. As these are applied against subjects rather
+than steps, only `expectedAttributes` is supported.
 
 ```yaml
 name: string

--- a/ITE/10/README.adoc
+++ b/ITE/10/README.adoc
@@ -65,6 +65,10 @@ information in their opaque environment and byproducts fields. To validate their
 contents, supply chain owners must rely on custom verification scripts invoked
 as inspections.
 
+In this ITE, the layout is updated to support a third type of policy
+specification, against attestation subjects. The updated layout schema can be
+found link:layout.proto[here].
+
 === Classifying Predicates
 
 Prior to ITE-6, all steps were validated against in-toto links. Inspection
@@ -104,21 +108,30 @@ source code represented by an in-toto link can use in-toto's artifact rules to
 ensure the review was performed against the sources fetched by the checkout
 step.
 
-=== Constraints
+=== Step Constraints
 
 As noted before, current in-toto layouts constraints are expressed via artifact
 rules. As the previous in-toto verification model primarily focused on steps
 that affected artifacts, constraints on custom attributes recorded in opaque
 fields such as environment and byproducts were left to inspections. With the
 rise of attribute focused predicates, in-toto layouts must support setting
-constraints on their contents.
+constraints on their contents. Further, while in-toto layouts always supported
+verifying multiple attestations for a step via the threshold functionality, they
+must now support verifying attestations of different predicate types generated
+during the execution of a single step.
 
 As such, this ITE proposes the following schema for step declarations.
 
 ```yaml
 name: string
 command: string
-predicates: list of TypeURIs
+expectedPredicates: list of ExpectedStepPredicates
+```
+
+Each `ExpectedStepPredicate` object has the following schema.
+
+```yaml
+predicateTypes: list of TypeURIs
 expectedMaterials: list of constraints
 expectedProducts: list of constraints
 expectedAttributes: list of constraints
@@ -141,17 +154,49 @@ language: string
 rule: object
 ```
 
-=== Role of Inspections
+=== Subject Constraints
 
-Inspections are primarily used at verification time to examine the final 
-products and their in-toto metadata. They may be of two types. In the first,
-inspections largely function like they do in the current in-toto specification.
-They are used as a mechanism to execute custom checks during the verification
-workflow. Their `expectedMaterials` and `expectedProducts` fields are similarly
-enhanced with support for policy languages alongside in-toto artifact rules, and
-they're joined by `expectedAttributes` like step definitions. By default,
-inspections are expected to generate in-toto links. However, the inspection
-declaration may specify an alternative predicate the check may result in.
+An alternative approach to applying policies for a software supply chain is
+against the artifacts of the supply chain. Every in-toto attestation is created
+against one or more artifacts recorded as that attestation's `subject`. So, a
+new top-level (alongside steps) capability is proposed to verify claims that
+apply to attestation subjects.
+
+```yaml
+subject: string
+expectedPredicates: list of ExpectedSubectPredicates
+```
+
+The `subject` can be a pattern that is applied against all attestations in the
+bundle. Every attestation that contains a subject matching the pattern is parsed
+to extract the claims made. `ExpectedSubjectPredicate` is a condensed version of
+`ExpectedStepPredicate`.
+
+```yaml
+predicateTypes: list of TypeURIs
+expectedAttributes: list of constraints
+functionaries: list of strings
+threshold: int
+```
+
+The set of attestations collected for the subject may include those of a
+predicate type not explicitly required in the `expectedPredicates`
+field--they're silently ignored. Attribute policies specified for each expected
+predicate is applied to the corresponding attestation. The verification workflow
+fails if a required attestation (that matches predicate type and threshold of
+signers) is unavailable or if a constraint fails.
+
+=== Inspections
+
+Inspections are primarily used at verification time to examine the final
+products and their in-toto metadata. Inspections largely function like they do
+in the current in-toto specification. They are used as a mechanism to execute
+custom checks during the verification workflow. Their `expectedMaterials` and
+`expectedProducts` fields are similarly enhanced with support for policy
+languages alongside in-toto artifact rules, and they're joined by
+`expectedAttributes` like step definitions. By default, inspections are expected
+to generate in-toto links. However, the inspection declaration may specify an
+alternative predicate the check may result in.
 
 ```yaml
 name: string
@@ -162,33 +207,19 @@ expectedProducts: list of constraints
 expectedAttributes: list of constraints
 ```
 
-The second type of inspections do not execute a command or script to perform
-some check. Instead, they are used to apply constraints on the _subjects_ of
-in-toto attestations for a supply chain. Instead of `command`, the schema has a
-`subject` field that accepts one or more patterns that are applied against the
-subjects of all attestations in the bundle being verified. The claims from all
-attestations part of the verification whose subjects match the specified
-patterns are collated. The inspection's constraints are then applied to the
-claims pertaining to the subjects. As these are applied against subjects rather
-than steps, only `expectedAttributes` is supported.
-
-```yaml
-name: string
-subject: list of patterns
-predicates: list of TypeURIs
-expectedAttributes: list of constraints
-```
-
 === Verification Workflow
 
 As with the current in-toto specification, the verification workflow is
 presented with a root layout, public keys to verify the layout's signatures, and
-a bundle of in-toto attestations. The workflow, at a high level, can be
-described as follows:
+a bundle of in-toto attestations. As the verifier expects a certain set of
+predicate types, it is also expected to be aware of the class of each predicate.
+The workflow, at a high level, can be described as follows:
 
 .   The layout's signatures are verified using the provided keys.
 .   The layout is parsed and its validity, i.e. the expiration date, is
     checked.
+.   The layout's contents are validated: at least one of `steps`, `subjects`,
+    and `inspections` must be specified.
 .   For each step in the layout, the corresponding attestations are loaded. The
     attestations must match the expected predicate types. As each attestation
     is loaded, its signatures are first verified against expected signers for
@@ -199,19 +230,67 @@ described as follows:
     materials (and products if it's a link class attestation), the constraints
     specified in `expectedMaterials`, `expectedProducts`, and
     `expectedAttributes` are verified respectively.
-.   For each inspection:
-..  If the inspection expects a command run, the command is executed and a link
-    class attestation is generated. Then, the `expectedMaterials`,
-    `expectedProducts`, and `expectedAttributes` are applied against the
-    contents of the attestation.
-..  Else, the inspection applies against one or more subjects. The patterns
-    specified are against all subjects in every attestation in the bundle. The
-    attestations that match the patterns are parsed to extract their claims. If
-    the attestations signatures weren't verified already when verifying steps,
-    the signatures are verified now. Each claim is associated with the subject
-    it applies to, the predicate type of the claiming attestation, and the
-    functionary that signed the attestation. Finally, the `expectedAttributes`
-    constraints are applied against the collection of claims.
+.   For each subject in the layout, the pattern is applied against the
+    attestations bundle. The attestations that match the patterns are parsed to
+    extract their claims. Each claim is associated with the subject it applies
+    to, the predicate type of the claiming attestation, and the functionary that
+    signed the attestation (a threshold of signatures is verified). Finally, the
+    `expectedAttributes` constraints are applied against the collection of
+    claims.
+.   For each inspection in the layout, the command is executed and an
+    attestation is generated. Then, the `expectedMaterials`,`expectedProducts`,
+    and `expectedAttributes` are applied against the contents of the
+    attestation.
+
+This workflow may be encoded as follows.
+
+```go
+func Verify(layoutEnvelope, layoutKeys, attestations, now) {
+    verifyLayoutSignatures(layoutEnvelope, layoutKeys)
+
+    layout := layoutEnvelope.Payload
+    verifyLayoutExpiry(layout, now)
+
+    if layout.Steps == nil && layout.Subjects == nil && layout.Inspections == nil {
+        panic
+    }
+
+    for _, step := range layout.Steps {
+        stepAttestations := attestationsForStep(step.Name, attestations)
+        for _, predicate := range step.ExpectedPredicates {
+            predicateAttestations := attestationsForStepPredicate(predicate.Type, stepAttestations)
+            if predicate.Type == LAYOUT {
+                Verify(predicateAttestations[0], predicate.Functionaries, predicateAttestations[1:], now)
+            } else {
+                verifyAttestationSignatures(predicate.Functionaries, predicate.Threshold, predicateAttestations)
+                for _, attestation := range predicateAttestations {
+                    applyMaterialRules(predicate.ExpectedMaterials, attestation)
+                    applyProductRules(predicate.ExpectedProducts, attestation)
+                    applyAttributeRules(predicate.ExpectedAttributes, attestation)
+                }
+            }
+        }
+    }
+
+    for _, subject := range layout.Subjects {
+        subjectAttestations := attestationsForSubject(subject.Pattern, attestations)
+        for _, predicate := range subject.ExpectedPredicates {
+            predicateAttestations := attestationsForSubjectPredicate(predicate.Type, subjectAttestations) // DRY
+            verifyAttestationSignatures(predicate.Functionaries, predicate.Threshold, predicateAttestations)
+            for _, attestation := range predicateAttestations {
+                verifyAttributeRules(predicate.ExpectedAttributes, attestation)
+            }
+        }
+    }
+
+    for _, inspection := range layout.Inspections {
+        attestation := executeInspection(inspection.Command, inspection.PredicateType)
+        applyMaterialRules(inspection.ExpectedMaterials, attestation)
+        applyProductRules(inspection.ExpectedProducts, attestation)
+        applyAttributeRules(inspection.ExpectedAttributes, attestation)
+    }
+}
+```
 
 [[motivation]]
 == Motivation

--- a/ITE/10/README.adoc
+++ b/ITE/10/README.adoc
@@ -1,0 +1,323 @@
+= ITE-10: Layouts for in-toto Attestations
+:source-highlighter: pygments
+:toc: preamble
+:toclevels: 2
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
+.Metadata
+[cols="2"]
+|===
+| ITE
+| 10
+
+| Title
+| Layouts for in-toto Attestations
+
+| Sponsor
+| link:https://github.com/adityasaky[Aditya Sirish A Yelgundhalli]
+
+| Status
+| Draft
+
+| Type
+| Standards
+
+| Created
+| 2023-01-07
+
+|===
+
+[[abstract]]
+== Abstract
+
+A previous in-toto Enhancement, ITE-6, presented the in-toto Attestation
+framework. This framework introduced the idea of context-specific attestations
+with their own definitions. This ITE builds on ITE-6 and proposes several
+modifications to in-toto layouts that allow for defining and verifying policies
+over ITE-6 attestations.
+
+[[specification]]
+== Specification
+
+=== Changes to Metadata Schema
+
+The in-toto specification describes the following schema for layouts.
+
+```
+{
+    "_type": "layout",
+    "expires": "<EXPIRES>",
+    "readme": "<README>",
+    "keys": {
+        "<KEYID>": "<PUBKEY_OBJECT>"
+    },
+    "steps": ["<STEP>", "..."],
+    "inspect": ["<INSPECTION>", "..."]
+}
+```
+
+As a whole, in-toto breaks down every software supply chain into a number of
+steps. The specification's verification workflow uses in-toto link metadata for
+each step to ensure it was performed correctly. Each step has the following
+schema.
+
+```
+{
+    "_type": "step",
+    "name": "<NAME>",
+    "threshold": "<THRESHOLD>",
+    "expected_materials": [
+        [ "<ARTIFACT_RULE>" ],
+        "..."
+    ],
+    "expected_products": [
+        [ "<ARTIFACT_RULE>" ],
+        "..."
+    ],
+    "pubkeys": ["<KEYID>", "..."],
+    "expected_command": "<COMMAND>"
+}
+```
+
+This ITE proposes modifying the step object to account for different types of
+rules. First, artifact rules recorded for `expected_materials` and
+`expected_products` are collected within a single field called
+`expected_artifacts`. These rules can be verified against in-toto link
+attestations or equivalent attestations accepted via ITE-9 such as SLSA
+Provenance. Second, this ITE adds an `expected_properties` field. Every entry in
+this field is expected to be some property a valid execution of the step is
+expected to possess, and the updated in-toto verification workflow passes only
+if the attestations presented can be validated as meeting every property. The
+updated step definition has the following schema.
+
+```
+{
+    "_type": "step",
+    "name": "<NAME>",
+    "expected_artifacts": {
+        "threshold": "<THRESHOLD>",
+        "pubkeys": ["<KEYID>", "..."],
+        "materials": [
+            [ "<ARTIFACT_RULE>" ],
+            "..."
+        ],
+        "products": [
+            [ "<ARTIFACT_RULE>" ],
+            "..."
+        ]
+    },
+    "expected_properties": {
+        "<PROPERTY_NAME>": {
+            "pubkeys": ["<KEYID>", "..."],
+            "threshold": "<THRESHOLD>"
+        }
+    },
+    "expected_command": "<COMMAND>"
+}
+```
+
+Similarly, each in-toto inspection object is updated to allow for properties. As
+inspections are run during verification, there is no expectation for authorized
+`pubkeys` or `threshold`. As such, the `expected_properties` field is just a
+list of property names.
+
+```
+{
+    "_type": "step",
+    "name": "<NAME>",
+    "expected_artifacts": {
+        "materials": [
+            [ "<ARTIFACT_RULE>" ],
+            "..."
+        ],
+        "products": [
+            [ "<ARTIFACT_RULE>" ],
+            "..."
+        ]
+    },
+    "expected_properties": ["<PROPERTY_NAME>", "..."],
+    "run": "<COMMAND>"
+}
+```
+
+NOTE: Do we consider replacing artifact rules altogether?
+
+The rules for each property validation are recorded in a new field in the
+layout, outside of the step definitions. These definitions can thus be reused
+across steps in the software supply chain.
+
+NOTE: We should evaluate inline policy definitions / extensions.
+
+Additionally, software supply chain owners can define policies for properties
+that apply to the supply chain as a whole rather than any one step. In some
+cases, these properties may apply to two or more steps. Therefore, the updated
+layout schema also supports `expected_properties` at the layout-wide level.
+Aside from the standard `pubkeys` and `threshold` fields, it also includes a
+`steps` field. During verification of a layout-wide policy, attestations from
+the listed steps are made available to it. The `steps` field is optional and
+these properties can also be satisfied with layout-specific attestations rather
+than step-specific attestations. All layout-specific attestations are made
+available to every property listed here, even if the `steps` field is used.
+
+```
+{
+    "_type": "layout",
+    "expires": "<EXPIRES>",
+    "readme: "<README>",
+    "keys": {
+        "<KEYID>": "<PUBKEY_OBJECT>"
+    },
+    "properties": {
+        "<PROPERTY_NAME>": {
+            "accepted_attestation_types": ["<PREDICATE_TYPE>", ...]
+            "policy_language": "<POLICY_LANGUAGE>", // FIXME: see NOTE about supporting multiple languages
+            "policy": "<POLICY>"
+        }
+    }
+    "expected_properties": {
+        "<PROPERTY_NAME>": {
+            "steps": ["<STEP_NAME>", "..."],
+            "pubkeys": ["<KEYID>", "..."],
+            "threshold": "<THRESHOLD>"
+        }
+    }
+    "steps": ["<STEP>", "..."],
+    "inspect": ["<INSPECTION>", "..."]
+}
+```
+
+All ITE-6 attestations have a `PREDICATE_TYPE` identifying the type of
+predicate. For each property, software supply chain owners can specify a list of
+acceptable predicates that can be used to meet the policy. The use of `<POLICY>`
+and `<POLICY_LANGUAGE>` are elaborated in a standalone section.
+
+=== Specifying Policies for Properties
+
+This ITE proposes the use of existing policy definition languages such as Rego
+and CUE. Note that embedding the policies themselves can be complicated by the
+wireline format used by a particular in-toto implementation. In general,
+`POLICY_LANGUAGE` must unambiguously identify the language and the `POLICY`
+must contain the policy itself in the specified language. For example, if an
+implementation uses some flavor of JSON for its metadata, the policy may be
+Base64 encoded and then stored in the layout.
+
+NOTE: FIXME, we need a separate evaluation of policy languages, and we should
+decide if we pick a winner / allow for multiple.
+
+TODO: if we are not picking one or more winners, we should enumerate the
+properties of acceptable policy languages. However, I'm leaning towards picking
+winners and expanding them with future ITEs if necessary.
+
+NOTE: FIXME, is there a better way to do this? Detached policies?
+
+=== Validating Policies for a Step
+
+The in-toto verification workflow specified in the specification is updated to
+include the verification of policies for expected properties of each step.
+Specifically, alongside link metadata, the verification workflow looks must be
+presented with attestations of the types allowed for a particular property,
+defined in the `accepted_attestation_types` field.
+
+Every attestation that is loaded has its signatures validated to ensure the
+metadata was generated by authorized keys (and by extension, functionaries).
+Next, the `POLICY` for each property is executed against the loaded
+attestations. If the policy executes to `true`, the property is deemed to be
+verified and the workflow moves on to the next property.
+
+TODO: Include examples of policies evaluating to `true` for some property.
+
+[[motivation]]
+== Motivation
+
+The original in-toto specification defined only one type of metadata that was to
+be captured during supply chain operations. As such, it had a uniform
+verification workflow and provided supply chain owners the semantics, i.e.
+artifact rules, to verify the flow of artifacts in their supply chains. ITE-6
+expanded the metadata formats to support the generation of custom attestations
+that have context-specific schemas. Current in-toto layouts as defined in the
+in-toto specification cannot be used to verify the information contained in
+these attestations.
+
+This ITE partitions attestations into two categories. Attestations can contain
+information about the flow of artifacts, like in-toto link metadata, and they
+can contain information about other properties of the supply chain. As such, the
+proposed changes to the layout in this ITE allow supply chain owners to define
+artifact rules for the former and policies verifying the existence of desirable
+properties for the latter.
+
+[[reasoning]]
+== Reasoning
+
+The intent of ITE-6 and the in-toto Attestation framework is to enable software
+producers to emit a wide range of contextual information pertaining to their
+supply chain. The intent of this ITE is to extend ITE-6 with policy definitions
+such that attestation producers can validate the information in ITE-6
+attestations. It is clear from ITE-6 that there is not a one-size-fits-all
+solution to policy definitions. Therefore, to support a wide variety of use
+cases, this ITE proposes the use of existing policy languages such as Rego and
+CUE.
+
+=== Rego
+
+Rego is a declarative policy language that is part of Open Policy Agent (OPA).
+Rego policies are composed of assertion queries that are applied against some
+specified data. If the data does not meet every assertion specified for it, the
+policy fails.
+
+Within the context of in-toto attestations, Rego can be used to define a set of
+rules for the data contained within predicates. If every assertion passes for
+some presented attestation, the in-toto verification workflow considers the
+property corresponding to the policy as met.
+
+The use of Rego over in-toto attestations is not new. Witness, an in-toto
+implementation by TestifySec supports the use of Rego policies.
+
+=== CUE
+
+CUE is a data validation language that can be used to validate data and schemas.
+It can be used to define constraints for some input data, and validation fails
+if the input data does not meet the specified constraints. As with Rego, CUE can
+be used to define rules for the data contained within in-toto predicates. During
+verification, if some attestation is presented that does not meet all the
+specified constraints, verification is unsuccessful. On the other hand, if all
+the constraints specified for a property's policy are met by the attestation,
+verification of that property is successful.
+
+[[backwards-compatibility]]
+== Backwards Compatibility
+
+This ITE significantly affects the backwards compatibility of in-toto metadata.
+For starters, the layout schema changes quite significantly. However, layouts
+that conform to the in-toto specification can be converted to the schema
+proposed here and therefore implementations conforming to this ITE can verify
+old layouts. On the other hand, old implementations cannot verify layouts
+conforming to this schema.
+
+[[security]]
+== Security
+
+
+[[infrastructure-requirements]]
+== Infrastructure Requirements
+
+
+[[prototype-implementation]]
+== Prototype Implementation
+
+None yet.
+
+[[testing]]
+== Testing
+
+
+[[references]]
+== References
+
+* link:https://www.openpolicyagent.org/docs/latest/policy-language/[Rego: Open Policy Agent's Policy Language]
+* link:https://cuelang.org/docs/about/[CUE]

--- a/ITE/10/README.adoc
+++ b/ITE/10/README.adoc
@@ -45,163 +45,153 @@ over ITE-6 attestations.
 [[specification]]
 == Specification
 
-The in-toto specification describes the following schema for layouts.
+Note: this document assumes the reader is familiar with ITE-6 and the in-toto
+Attestation Framework.
 
-```json
-{
-    "_type": "layout",
-    "expires": "<EXPIRES>",
-    "readme": "<README>",
-    "keys": {
-        "<KEYID>": "<PUBKEY_OBJECT>"
-    },
-    "steps": ["<STEP>", "..."],
-    "inspect": ["<INSPECTION>", "..."]
-}
+in-toto layouts have two key mechanisms for specifying policies: steps and
+inspections. Steps are used to reason about and express constraints regarding
+operations performed as part of the supply chain. Constraints are currently
+expressed using in-toto artifact rules against the materials and products of a
+step. Each step definition also declares the set of functionaries authorized to
+perform the step and the required number of functionaries that need to sign off
+on the step.
+
+Inspections, on the other hand, are executed during the verification workflow to
+complement in-toto's step verifications with extra checks. Typically,
+inspections invoke external commands or scripts shipped with the layout. They
+may also use artifact rules. Currently, inspections are used for constraints
+in-toto layouts do not support. For example, in-toto links can record arbitrary
+information in their opaque environment and byproducts fields. To validate their
+contents, supply chain owners must rely on custom verification scripts invoked
+as inspections.
+
+=== Classifying Predicates
+
+Prior to ITE-6, all steps were validated against in-toto links. Inspection
+executions also resulted in the generation of in-toto links that were then
+validated. With the introduction of the in-toto Attestation Framework, it is
+necessary to rework the layout to support verifying a variety of _predicates_.
+As the framework is designed to generate claims pertaining to how software is
+produced, each predicate type can be mapped to a step in the software supply
+chain. However, it is first necessary to understand the nature of each step, and
+therefore its predicate type. in-toto was originally designed with the
+assumption that a step in the software supply chain affects in some manner the
+artifacts that constitute the supply chain. ITE-6 showed that some steps do not
+fit the materials and products model. This is a factor in _verifying_ such
+predicates using in-toto layouts.
+
+Therefore, all predicates supported for verification in an in-toto layout must
+categorized as one of two types:
+
+* the link type: these are based on classic in-toto links for steps that affect
+  artifacts in some manner. They consume some artifacts as materials and produce
+  others as products. The subject of such attestations indicate the products of
+  the step. Eg. in-toto links, SLSA Provenance.
+* the attribute type: these predicates record contextual attributes about one or
+  more artifacts. The operations they represent consume artifacts as materials
+  (recorded as the subject of such attestations) and produce attributes about
+  them as the outcome. Eg. test results, reviews.
+
+Note that predicates that fit the first category may also record certain
+attributes. For example, the environment field in in-toto links can include such
+attribute information.
+
+With this representation of different predicate types, step declarations in
+layouts can _chain_ different operations represented by distinct predicate types
+together, a fundamental feature of in-toto. For example, a code review step
+represented by a review predicate type that follows a checkout step that fetches
+source code represented by an in-toto link can use in-toto's artifact rules to
+ensure the review was performed against the sources fetched by the checkout
+step.
+
+=== Constraints
+
+As noted before, current in-toto layouts constraints are expressed via artifact
+rules. As the previous in-toto verification model primarily focused on steps
+that affected artifacts, constraints on custom attributes recorded in opaque
+fields such as environment and byproducts were left to inspections. With the
+rise of attribute focused predicates, in-toto layouts must support setting
+constraints on their contents.
+
+As such, this ITE proposes the following schema for step declarations.
+
+```yaml
+name: string
+command: string
+predicates: list of TypeURIs
+expectedMaterials: list of constraints
+expectedProducts: list of constraints
+expectedAttributes: list of constraints
+functionaries: list of strings
+threshold: int
 ```
 
-An in-toto layout provides two semantics for software supply chain owners to
-define policies: steps and inspections. Steps are used to reason about and
-express constraints regarding operations _already_ performed as part of the
-supply chain. The verification is focused on ensuring authorized functionaries
-performed each step and validating the integrity of artifacts as they move from
-one step to the next. Inspections are executed _during_ verification to perform
-any other checks that are defined as external scripts.
+Each entry in `expectedMaterials`, `expectedProducts`, and `expectedAttributes`
+corresponds to one rule, similar to the current in-toto layouts. However, along
+with in-toto artifact rules, other DSLs may be used to specify attribute
+specific constraints. Languages such as Rego, CUE, and CEL have been designed to
+enable such schema and data validation. Each constraint must identify the DSL
+used to ensure the verification engine can appropriately handle the rules. In
+some cases, the actual rules may need to be encoded in some form prior to
+embedding in the layout. The verification engine uses the information about the
+language to identify how to parse the rule.
 
-TODO: this pass does not revise artifact rules for steps.
-
-This ITE primarily updates the schema and capabilities for inspections. As it
-stands, the inspections semantic can already be used to apply arbitrary
-constraints to data captured in in-toto links. Similarly, they can apply
-constraints to attestations as well. We update in-toto inspections with more
-capabilities so that they do not necessarily have to be executed as separate
-scripts. This is achieved by providing multiple options for the domain specific
-language used to express constraints. Currently, inspections only support using
-in-toto's artifact rules. With this ITE, this will remain an option, but
-inspections can also be written to not execute separate shell scripts and use
-artifact rules, and instead express data constraints using DSLs like Rego or
-Cue. The current inspection schema is as follows:
-
-```json
-{
-    "_type": "inspection",
-    "name": "<NAME>",
-    "expected_materials": [
-        [ "<ARTIFACT_RULE>" ],
-        "..."
-    ],
-    "expected_products": [
-        [ "<ARTIFACT_RULE>" ],
-        "..."
-    ],
-    "run": "<COMMAND>"
-}
+```yaml
+language: string
+rule: object
 ```
 
-The above schema can also be expressed using the following generalization that
-allows for multiple DSLs. Note that several fields are optional.
+=== Verification Workflow
 
+After verifying the layout and attestation signatures (including thresholds
+where applicable), attestations must be parsed to identify the materials and
+products of the step they represent. In link type predicates, the materials are
+found within the predicate and products are recorded as the attestation's
+subject. Note that alongside these artifacts, other predicate fields excluding
+the materials must also be parsed in as part of the products to enable policies
+on their contents.  For attribute type predicates, the materials are the
+attestation's subject and products are exclusively the attributes recorded
+within the predicate.
 
-```json
-{
-    "_type": "inspection",
-    "name": "<NAME>",
-    "functionaries": ["<KEYID>", "..."],
-    "threshold": "<THRESHOLD>",
-    "subject": ["<SUBJECT>", "..."],
-    "policyLanguage": "<POLICY_LANGUAGE>",
-    "policy": "<POLICY>",
-    "run": "<COMMAND>"
-}
+With this internal representation of all attestations created, each step's
+material policies are applied against the material artifacts. If an error is
+encountered, the verification workflow is terminated. If not, the workflow
+proceeds to the product policies.
+
+=== Role of Inspections
+
+Inspections are primarily used at verification time to examine the final 
+products and their in-toto metadata. They may be of two types. In the first,
+inspections largely function like they do in the current in-toto specification.
+They are used as a mechanism to execute custom checks during the verification
+workflow. Their materials and products fields are similarly enhanced with
+support for policy languages alongside in-toto artifact rules. By default,
+inspections are expected to generate in-toto links. However, the inspection
+declaration may specify an alternative predicate the check may result in.
+
+```yaml
+name: string
+command: string
+predicates: list of TypeURIs
+expectedMaterials: list of constraints
+expectedProducts: list of constraints
+expectedAttributes: list of constraints
 ```
 
-Currently supported inspections _always_ execute a command or script and
-generate link metadata. As this is during verification, they are not signed. As
-such, to support the current model, `functionaries` and `threshold` are
-optional. Similarly, `subject` is also unnecessary. `policyLanguage` is used to
-indicate the policy is expressed as in-toto artifact rules and `policy` contains
-the actual rules currently expressed as `expected_materials` and
-`expected_products`.
+The second type of inspections do not execute a command or script to perform
+some check. Instead, they are used to apply constraints on the _subjects_ of
+in-toto attestations for a supply chain. Instead of `command`, the schema has a
+`subject` field that accepts one or more patterns. The claims from all
+attestations part of the verification whose subjects match the specified
+patterns are collated. The inspection's constraints are then applied to the
+claims pertaining to the subjects.
 
-However, this model provides a lot of flexibility when it comes to other DSLs.
-Consider the following subset of the block above:
-
-```json
-{
-    "_type": "inspection",
-    "name": "<NAME>",
-    "functionaries": ["<KEYID>", "..."],
-    "threshold": "<THRESHOLD>",
-    "subject": ["<SUBJECT>", "..."],
-    "policyLanguage": "<POLICY_LANGUAGE>",
-    "policy": "<POLICY>",
-}
+```yaml
+name: string
+subject: list of patterns
+predicates: list of TypeURIs
+expectedAttributes: list of constraints
 ```
-
-Only `run` is removed as in this example, an external command or script is not
-invoked. Instead, the `policyLanguage` used is a logic programming language and
-the `policy` expresses directly the checks that previously needed to be a
-separate script. Here, `subject` is used to identify the sets of attestations
-the policy is applied against. Further, the `functionaries` and `threshold`
-fields can be used to directly check the source of the claims being verified by
-the policy. In the current model, as inspections reason about link metadata
-generated for the execution of the inspection itself, any inspection that
-used a script to check contents of link metadata from some prior step also
-needed to verify the functionary signing the metadata in the script--in-toto's
-semantics are not used directly.
-
-TODO: the last bit of the paragraph is very convoluted. What I'm trying to say
-is that inspection scripts must also reason about and verify any prior metadata
-they're looking at is signed by the right keys, with the right threshold, and so
-on. They cannot just verify the claims themselves. This is important because:
-1. you may have link metadata that was signed by the wrong functionary, rejected
-   during verification of the step, but the threshold was still met. Claims made
-   by this metadata shouldn't be trusted by inspections.
-2. you may have link metadata with differing attributes for the same step by
-   design. One example: reproducible builds with one piece of metadata generated
-   by an isolated environment. The inspection here should be able to reason
-   about which metadata has these claims and if it's from the right environment.
-
-Note that a policy specified in an inspection block is not applied to some
-specified set of attestation types. Policies apply to _subjects_ of the supply
-chain, whether artifacts or other processes captured using ITE-4 semantics.
-During the verification workflow, all attestations are parsed to represent their
-claims in the context of the subjects they apply to. So, all available
-information for a subject is available along with the functionaries signing for
-each individual claim, and this representation of attestation claims is used to
-apply policies. Attestations must not be parsed if their signatures cannot be
-verified using functionary information available in the layout.
-
-=== Specifying Policies
-
-In general, each unit policy applies one constraint. For example, a policy might
-mirror in-toto's artifact rules, ensuring that all the materials and products of
-some step in the supply chain are as expected. Alternatively, a policy can apply
-a property-oriented constraint to an artifact or step, such as validating the
-Provenance of an artifact or that its build process was performed in an isolated
-and hermetic build environment. Note that all of these types of policies can
-coexist and successful verification is contingent on all policy validations
-succeeding.
-
-This indicates that developers need a great deal of flexibility in specifying
-policies _and_ that any domain-specific language chosen or created to express
-policies must have the necessary capabilities to fit these requirements.
-
-Prior literature has explored the use of logic based languages and their
-derivatives for specifying and validating policies. Policies, at their core, are
-logic programs that are applied against a set of claims, expressed here as
-in-toto attestations. This ITE uses languages such as Rego and CUE as examples
-of such languages, but leaves the specific choices to the in-toto community and
-adopters. The new layout schema proposed above includes a `<POLICY_LANGUAGE>`
-attribute for each policy to enable this variety in choice.
-
-=== Validating Policies
-
-The in-toto verification workflow is updated to support different types of
-inspections as defined in this ITE. For new style inspection blocks, the
-verification workflow uses the `policyLanguage` field to decide which policy
-engine to use. If `run` is specified, the workflow executes the command or
-script as it does now.
 
 [[motivation]]
 == Motivation
@@ -219,40 +209,26 @@ directly reason about the sources of claims made in them.
 [[reasoning]]
 == Reasoning
 
+This ITE presents certain changes that necessitate further reasoning.
+
+=== Predicate Classification
+
+One of in-toto's key properties is the ability to chain different steps
+together, and therefore verifying every step used the right artifacts. By
+classifying predicates based on the type of step they represent, we gain the
+ability to place attestations that exclusively contain claims about artifacts in
+the steps graph.
+
+=== New Policy Languages
+
 The intent of ITE-6 and the in-toto Attestation framework is to enable software
 producers to emit a wide range of contextual information pertaining to their
 supply chain. The intent of this ITE is to extend ITE-6 with policy definitions
 such that attestation producers can validate the information in ITE-6
 attestations. It is clear from ITE-6 that there is not a one-size-fits-all
 solution to policy definitions. Therefore, to support a wide variety of use
-cases, this ITE proposes the use of existing policy languages such as Rego and
-CUE.
-
-=== Rego
-
-Rego is a declarative policy language that is part of Open Policy Agent (OPA).
-Rego policies are composed of assertion queries that are applied against some
-specified data. If the data does not meet every assertion specified for it, the
-policy fails.
-
-Within the context of in-toto attestations, Rego can be used to define a set of
-rules for the data contained within predicates. If every assertion passes for
-some presented attestation, the in-toto verification workflow considers the
-property corresponding to the policy as met.
-
-The use of Rego over in-toto attestations is not new. Witness, an in-toto
-implementation by TestifySec supports the use of Rego policies.
-
-=== CUE
-
-CUE is a data validation language that can be used to validate data and schemas.
-It can be used to define constraints for some input data, and validation fails
-if the input data does not meet the specified constraints. As with Rego, CUE can
-be used to define rules for the data contained within in-toto predicates. During
-verification, if some attestation is presented that does not meet all the
-specified constraints, verification is unsuccessful. On the other hand, if all
-the constraints specified for a property's policy are met by the attestation,
-verification of that property is successful.
+cases, this ITE proposes the use of existing policy languages such as Rego, CUE,
+and CEL.
 
 [[backwards-compatibility]]
 == Backwards Compatibility
@@ -286,3 +262,4 @@ None yet.
 
 * link:https://www.openpolicyagent.org/docs/latest/policy-language/[Rego: Open Policy Agent's Policy Language]
 * link:https://cuelang.org/docs/about/[CUE]
+* link:https://github.com/google/cel-spec[CEL]

--- a/ITE/10/concise.adoc
+++ b/ITE/10/concise.adoc
@@ -1,0 +1,275 @@
+= ITE-10: Supporting Contextual in-toto Attestations in Layouts
+:source-highlighter: pygments
+:toc: preamble
+:toclevels: 2
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
+.Metadata
+[cols="2"]
+|===
+| ITE
+| 10
+
+| Title
+| Supporting Contextual in-toto Attestations in Layouts
+
+| Sponsor
+| link:https://github.com/adityasaky[Aditya Sirish A Yelgundhalli]
+
+| Status
+| Draft
+
+| Type
+| Standards
+
+| Created
+| 2023-01-07
+
+|===
+
+[[abstract]]
+== Abstract
+
+TODO
+
+[[specification]]
+== Specification
+
+Note: this document assumes the reader is familiar with ITE-6 and the in-toto
+Attestation Framework.
+
+To support different predicate types in an in-toto layout's steps and
+inspections, it is first necessary to recognize that there are two broad classes
+of predicates.
+
+=== Classifying Predicates
+
+Prior to ITE-6, all steps were validated against in-toto links. Inspection
+executions also resulted in the generation of in-toto links that were then
+verified. With the introduction of the in-toto Attestation Framework, it is
+necessary to rework the layout to support verifying a variety of _predicates_.
+As the framework is designed to generate claims pertaining to how software is
+produced, each predicate type can be mapped to a step in the software supply
+chain. However, it is first necessary to understand the nature of each step, and
+therefore its predicate types. in-toto was originally designed with the
+assumption that a step in the software supply chain affects in some manner the
+artifacts that constitute the supply chain. ITE-6 showed that some steps do not
+fit the materials and products model. This is a factor in _verifying_ such
+predicates using in-toto layouts.
+
+Therefore, all predicates supported for verification in an in-toto layout must
+categorized as one of two classes:
+
+* transformational predicates: these are based on classic in-toto links for
+  steps that transform artifacts in some manner. They consume some artifacts as
+  materials and produce others as products. The subject of such attestations
+  indicate the products of the step. Eg. in-toto links, SLSA Provenance.
+* informational predicates: these predicates record contextual attributes about
+  one or more artifacts. The operations they represent consume artifacts as
+  materials (recorded as the subject of such attestations) and produce
+  attributes about them as the outcome. Eg. test results, reviews.
+
+Note that transformational predicates may also record certain information about
+certain attributes. For example, the environment field in in-toto links can
+include such information.
+
+With this representation of different predicate types, step declarations in
+layouts can _chain_ different operations represented by distinct predicate types
+together, a fundamental feature of in-toto. For example, a code review step
+represented by a review predicate type that follows a checkout step that fetches
+source code represented by an in-toto link can use in-toto's artifact rules to
+ensure the review was performed against the sources fetched by the checkout
+step.
+
+=== Setting Predicate Type Expectations for Steps and Inspections
+
+Currently, step declarations have the following schema.
+
+```yaml
+name: string
+threshold: int
+expectedMaterials: list of artifact rules
+expectedProducts: list of artifact rules
+pubkeys: list of authorized key IDs
+expectedCommand: list of strings
+```
+
+This ITE proposes updating this schema to incorporate predicate types.
+
+```yaml
+name: string
+command: list of strings
+expectedMaterials: list of artifact rules
+expectedPredicates: list of expectedStepPredicates
+```
+
+Each `expectedStepPredicate` object has the following schema.
+
+```yaml
+predicateType: string
+expectedProducts: list of artifact rules
+functionaries: list of authorized functionary key IDs
+threshold: int
+```
+
+The `predicateType` field identifies the type of predicate expected for the
+step. `expectedProducts` is moved to being predicate specific as informational
+predicates may be generated alongside transformational predicates for the same
+step. This means that product rules do not generalize across all of the step's
+predicates. However, `expectedMaterials` is retained at the step level as all
+predicates generated for a step are expected to be for the same set of
+artifacts. `pubkeys` is updated to `functionaries` to generalize signing
+semantics. Finally, `threshold` applies per predicate type rather than the step
+as a whole.
+
+Similarly, inspections are also updated to support generating different
+predicate types.
+
+```yaml
+name: string
+command: list of strings
+expectedMaterials: list of artifact rules
+expectedPredicates: list of expectedInspectionPredicates
+```
+
+Each `expectedInspectionPredicate` object has the following schema.
+
+```yaml
+predicateType: string
+expectedProducts: list of artifact rules
+```
+
+As the attestations generated during inspection executions are not signed,
+`functionaries` and `threshold` are omitted.
+
+=== Supporting Sublayouts
+
+The in-toto specification has support for sublayouts which are steps in a layout
+that have not links but a bundle of another layout and links which are
+recursively verified first. To support this semantic, this ITE proposes making
+sublayout declarations explicit. Therefore, a step declaration declares that it
+expects a layout and identifies it. This layout is then verified recursively
+before verification continues at the original layout.
+
+=== Verifying Artifact Rules
+
+The verification workflow in the in-toto specification matches links to use by
+the name of the step and the key ID used to sign it. This part of the workflow
+is updated to support matching on predicate types as well.
+
+```go
+func Verify(layoutEnvelope, layoutKeys, attestations, now) {
+    verifyLayoutSignatures(layoutEnvelope, layoutKeys)
+
+    layout := layoutEnvelope.Payload
+    verifyLayoutExpiry(layout, now)
+
+    if layout.Steps == nil && layout.Inspections == nil {
+        panic
+    }
+
+    for _, step := range layout.Steps {
+        stepAttestations := attestationsForStep(step.Name, attestations)
+        for _, predicate := range step.ExpectedPredicates {
+            predicateAttestations := attestationsForStepPredicate(predicate.Type, stepAttestations)
+            if predicate.Type == LAYOUT {
+                Verify(predicateAttestations[0], predicate.Functionaries, predicateAttestations[1:], now)
+            } else {
+                verifyAttestationSignatures(predicate.Functionaries, predicate.Threshold, predicateAttestations)
+                for _, attestation := range predicateAttestations {
+                    applyMaterialRules(step.ExpectedMaterials, attestation.Materials, attestations)
+                    applyProductRules(predicate.ExpectedProducts, attestation.Products, attestations)
+                }
+            }
+        }
+    }
+
+    for _, inspection := range layout.Inspections {
+        expectedPredicateTypes := []string{}
+        for _, expectedPredicate := range inspection.ExpectedPredicates {
+            expectedPredicateTypes = append(expectedPredicateTypes, expectedPredicate.PredicateType)
+        }
+        inspectionAttestations := executeInspection(inspection.Command, expectedPredicateTypes) // {predicateType: attestation}
+        allAttestations := combineAttestations(inspectionAttestations, attestations)
+        for _, expectedPredicate := range inspection.ExpectedPredicates {
+            attestation := inspectionAttestations[expectedPredicate.PredicateType]
+            applyMaterialRules(inspection.ExpectedMaterials, attestation.Materials, allAttestations)
+            applyProductRules(expectedPredicate.ExpectedProducts, attestation.Products, allAttestations)
+        }
+    }
+}
+```
+
+[[motivation]]
+== Motivation
+
+The original in-toto specification defined only one type of metadata that was to
+be captured during supply chain operations. As such, it had a uniform
+verification workflow and provided supply chain owners the semantics, i.e.
+artifact rules, to verify the flow of artifacts in their supply chains. ITE-6
+expanded the metadata formats to support the generation of custom attestations
+that have context-specific schemas. Current in-toto layouts as defined in the
+in-toto specification and artifact rules cannot be used to verify artifacts
+recorded in ITE-6 predicates.
+
+[[reasoning]]
+== Reasoning
+
+This ITE presents certain changes that necessitate further reasoning.
+
+=== Predicate Classification
+
+One of in-toto's key properties is the ability to chain different steps
+together, and therefore verifying every step used the right artifacts. By
+classifying predicates based on the type of step they represent, we gain the
+ability to place attestations that exclusively contain claims about artifacts in
+the steps graph.
+
+[[backwards-compatibility]]
+== Backwards Compatibility
+
+All the capabilities currently enabled by in-toto inspections are retained in
+the changes proposed here. As such, there is no regression in capabilities.
+
+However, new layouts following the scheme specified here cannot be verified
+using older in-toto implementations. Implementations adopting the changes
+proposed in this ITE are encouraged to support legacy layouts for some period of
+time communicated to their users, allowing them to transition their layouts.
+
+[[security]]
+== Security
+
+This ITE does not significantly affect the security of in-toto layouts. It
+preserves all of the existing capabilities of in-toto layouts, meaning no
+existing properties are lost. It presents a consistent way to handle contextual
+predicates in artifact rules, meaning in-toto's powerful step-chaining
+properties can apply to the Attestation Framework.
+
+[[infrastructure-requirements]]
+== Infrastructure Requirements
+
+None.
+
+[[prototype-implementation]]
+== Prototype Implementation
+
+None yet.
+
+[[testing]]
+== Testing
+
+Implementations of this layout schema and the accompanying verification
+workflow must be thoroughly tested to ensure their backwards compatibility with
+old layouts.
+
+[[references]]
+== References
+
+* link:https://github.com/in-toto/docs/blob/master/in-toto-spec.md[in-toto Specification]
+* link:https://github.com/in-toto/attestation[in-toto Attestation Framework]

--- a/ITE/10/layout.proto
+++ b/ITE/10/layout.proto
@@ -1,0 +1,64 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+
+package in_toto.layout;
+
+option go_package = "github.com/in-toto/ite";
+
+message Functionary {
+    string type = 1;
+    string scheme = 2;
+    string value = 3;
+}
+
+message Constraint {
+    string type = 1;
+    string policy = 2;
+}
+
+message ExpectedStepPredicate {
+    repeated string predicate_types = 1; // supports oneof equivalent predicate types
+    repeated Constraint expected_materials = 2;
+    repeated Constraint expected_products = 3;
+    repeated Constraint expected_attributes = 4;
+    repeated string functionaries = 5;
+    int32 threshold = 6;
+}
+
+message Step {
+    string name = 1;
+    string command = 2;
+    repeated ExpectedStepPredicate expected_predicates = 3;
+}
+
+message ExpectedSubjectPredicate {
+    repeated string predicate_types = 1; // supports oneof equivalent predicate types
+    repeated Constraint expected_attributes = 2;
+    repeated string functionaries = 3;
+    int32 threshold = 4;
+}
+
+message Subject {
+    string name = 1;
+    string subject = 2;
+    repeated ExpectedSubjectPredicate expected_predicates = 3;
+}
+
+message Inspection {
+    string name = 1;
+    string command = 2;
+    repeated string predicates = 3;
+    repeated Constraint expected_materials = 4;
+    repeated Constraint expected_products = 5;
+    repeated Constraint expected_attributes = 6;
+}
+
+message Layout {
+    google.protobuf.Timestamp expires = 1;
+    string readme = 2;
+    map<string, Functionary> functionaries = 3;
+    repeated Step steps = 4;
+    repeated Subject subjects = 5;
+    repeated Inspection inspections = 6;
+}

--- a/ITE/11/README.adoc
+++ b/ITE/11/README.adoc
@@ -1,0 +1,286 @@
+= ITE-11: Verifying Attributes in in-toto Attestations
+:source-highlighter: pygments
+:toc: preamble
+:toclevels: 2
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
+.Metadata
+[cols="2"]
+|===
+| ITE
+| 11
+
+| Title
+| Verifying Attributes in in-toto Attestations
+
+| Sponsor
+| link:https://github.com/adityasaky[Aditya Sirish A Yelgundhalli]
+
+| Status
+| Active :smile:
+
+| Type
+| Process
+
+| Created
+| 2023-01-07
+
+|===
+
+[[abstract]]
+== Abstract
+
+TODO
+
+[[specification]]
+== Specification
+
+This ITE proposes embedding attribute verification capabilities within in-toto
+layouts. Specifically, it proposes a new step and inspection specific field
+called `expectedAttributes` that will live alongside the existing
+`expectedMaterials` and `expectedProducts` fields. Unlike those fields,
+`expectedAttributes` will not support artifact rules but will instead evaluate
+each rule using the Common Expression Language (CEL).
+
+If this ITE is applied to the original in-toto layout, the schema for each step
+would look as follows.
+
+```yaml
+name: string
+threshold: int
+expectedMaterials: list of artifact rules
+expectedProducts: list of artifact rules
+expectedAttributes: list of CEL expressions
+pubkeys: list of authorized key IDs
+expectedCommand: list of strings
+```
+
+If instead the ITE is applied to layouts with support for the in-toto
+Attestation Framework, the resultant step schema is as follows.
+
+```yaml
+name: string
+command: list of strings
+expectedMaterials: list of artifact rules
+expectedPredicates: list of expectedStepPredicates
+```
+
+Each `expectedStepPredicate` object has the following schema.
+
+```yaml
+predicateType: string
+expectedProducts: list of artifact rules
+expectedAttributes: list of CEL expressions
+functionaries: list of authorized functionary key IDs
+threshold: int
+```
+
+Similarly, inspections in legacy layouts are updated to the following schema.
+
+```yaml
+name: string
+expectedMaterials: list of artifact rules
+expectedProducts: list of artifact rules
+expectedAttributes: list of CEL expressions
+run: list of strings
+```
+
+And inspections in layouts with support for the Attestation Framework will have
+the following schema.
+
+```yaml
+name: string
+command: list of strings
+expectedMaterials: list of artifact rules
+expectedPredicates: list of expectedInspectionPredicates
+```
+
+Each `expectedInspectionPredicate` object has the following schema.
+
+```yaml
+predicateType: string
+expectedProducts: list of artifact rules
+expectedAttributes: list of CEL expressions
+```
+
+=== Verifying Attribute Constraints
+
+An in-toto implementation supporting these checks must support the evaluation of
+CEL expressions. During the in-toto verification workflow, after applying rules
+from `expectedMaterials` and `expectedProducts`, each rule is evaluated against
+the attestation it applies to. If the rule expression evaluates to true, the
+rule passes and verification proceeds. If the expression evaluates to false,
+verification is aborted with an error indicating the failing rule.
+
+[[motivation]]
+== Motivation
+
+in-toto attestations, whether links from the original in-toto specification or
+contextual metadata from the Attestation Framework, contain various claims. The
+link metadata format has two opaque fields, `environment` and `byproducts`, that
+can hold arbitrary information. Contextual predicates also record various
+software supply chain specific attributes, though in predefined fields rather
+than in an arbitrary manner in opaque fields. In the current in-toto
+specification, the only way to verify these attributes are through inspections
+that require executing commands or scripts during verification. If invoked via
+scripts, they need to be communicated alongside layouts to the verifier and
+there are no in-toto specific guarantees as to their integrity or if they were
+issued by the authors of the layout. Further, these scripts can be complicated
+as they need to load attestations, once again verify their signatures using keys
+in the layout, before they can actually validate the attributes in question.
+
+=== Example: Verifying Result of a Test Run
+
+The in-toto Attestation Framework has a vetted predicate capturing the results
+of test runs. To verify that the test result attestation indicates a successful
+test run, the following CEL rule can be used.
+
+```yaml
+...
+expectedAttributes:
+    - "result == 'PASSED'"
+...
+```
+
+=== Example: Verifying SLSA Provenance Attributes
+
+SLSA Provenance predicates record various attributes such as the identity of the
+builder, source repository, and various other parameters. These attributes can
+be verified in in-toto layouts as follows.
+
+```yaml
+...
+expectedAttributes:
+    - "runDetails.builder.id == '<expected value>'"
+    - "externalParameters.repository == '<expected value>'"
+    - "externalParameters.ref == '<expected value>'"
+...
+```
+
+=== Example: Verifying Build Isolation via Runtime Trace Attestation
+
+This vetted predicate is used to record a trace of some supply chain step, such
+as the build step. It can be used to verify that the builder made no network
+calls. But first, it is necessary to verify that the monitor was of an expected
+type and that its trace policy included tracking network calls.
+
+```yaml
+...
+expectedAttributes:
+    - "monitor.type == 'https://github.com/cilium/tetragon'"
+    - "monitor.tracePolicy.policies.exists(p, p['Name'] == 'connect')"
+    - "size(monitorLog.network) == 0"
+...
+```
+
+=== Example: Verifying Contents of Opaque Fields in in-toto Links
+
+As noted above, in-toto links have an opaque `byproducts` field that records
+additional information pertaining to the step performed. in-toto's verification
+workflow does not verify its contents by default. However, the changes proposed
+here can be used to add checks for its contents as well as those of the other
+opaque field, `environment`.
+
+```yaml
+...
+expectedAttributes:
+    - "size(byproducts['stderr']) == 0"
+    - "byproducts['return-value'] == 0"
+    - "environment['<key>'] == '<expected value>'"
+...
+```
+
+[[reasoning]]
+== Reasoning
+
+This ITE presents certain changes that necessitate further reasoning.
+
+=== Use of CEL
+
+CEL is a lightweight language designed for expression evaluations. One of its
+key applications is for security policies, making it a good fit for specifying
+attribute rules in in-toto layouts. CEL expressions are evaluated in linear time
+and the language is not Turing-complete, mitigating concerns about arbitrary
+executions during verification.
+
+Another feature making CEL a good fit for in-toto layout attribute checks is
+that it was designed to be embedded in other applications. Indeed, in-toto is
+not the first system to support embedded CEL expressions--Kubernetes also
+supports using CEL to declare various constraints as does Envoy in its Role
+Based Access Control policies.
+
+=== Supporting Other Languages
+
+Other policy specific languages such as Open Policy Agent's Rego and CUE are
+alternatives to using CEL. Supporting them (and identifying the language used
+for a rule) is an open discussion point. CEL is simpler to write and embed into
+in-toto layouts but is also less powerful. That said, the focus is on setting
+constraints on attributes recorded in in-toto attestations, which CEL is capable
+enough for. This may change if use cases emerge that CEL cannot express
+constraints for. It's also worth noting that for niche scenarios, the original
+method of writing custom inspections also remains an option.
+
+[[backwards-compatibility]]
+== Backwards Compatibility
+
+This ITE is entirely backwards compatible with both the original layout schema
+and the updated one with support for the in-toto Attestation Framework. It adds
+one field to step and inspection declarations. Old in-toto implementations can
+safely ignore this field with the impact being the lack of attribute
+verification. This does not weaken in any way the security properties of such
+scenarios.
+
+[[security]]
+== Security
+
+There are two aspects to the security implications of this ITE. The first is the
+addition of a substantial surface--the in-toto specification is at least in part
+dependent on the CEL specification, and implementations are similarly dependent
+on the CEL engine. TODO: flesh this out some more.
+
+On the other hand, by moving straightforward attribute checks into the in-toto
+layout, adopters no longer have to write convoluted scripts that can load
+layouts, load attestations, verify their signatures, before actually performing
+the attribute checks. As in-toto implementations have to perform these
+operations anyway (and in a well defined manner per the specification), such
+complicated scripts can be retired. Further, in-toto verifiers shell out and
+execute these inspection scripts in the _verification environment_. As layouts
+do not perform any integrity checks for these scripts (though in-toto's sister
+project TUF can be leveraged via ITE-2), in-toto cannot provide guarantees of
+the code being executed.
+
+[[infrastructure-requirements]]
+== Infrastructure Requirements
+
+None.
+
+[[prototype-implementation]]
+== Prototype Implementation
+
+None yet.
+
+[[testing]]
+== Testing
+
+Implementations of this layout schema and the accompanying verification
+workflow must be thoroughly tested to ensure their backwards compatibility with
+old layouts. Further, layouts with CEL rules must be used to test the dependency
+on the CEL engine.
+
+[[references]]
+== References
+
+* link:https://github.com/google/cel-spec[CEL]
+* link:https://github.com/in-toto/docs/blob/master/in-toto-spec.md[in-toto Specification]
+* link:https://github.com/in-toto/attestation[in-toto Attestation Framework]
+* link:https://kubernetes.io/docs/reference/using-api/cel/[CEL in Kubernetes]
+* link:https://www.openpolicyagent.org/docs/latest/policy-language/[Rego: Open Policy Agent's Policy Language]
+* link:https://cuelang.org/docs/about/[CUE]
+* link:https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/rbac_filter[CEL in Envoy]
+* link:../2/README.adoc[ITE-2]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 * [ITE-6: Generalized link format](ITE/6/README.md)
 * [ITE-7: Signing & Verification With X509](ITE/7/README.adoc)
 * [ITE-9: Introducing new in-toto Attestation types](ITE/9/README.adoc)
+* [ITE-10: Layouts for in-toto Attestations](ITE/10/README.adoc)
 
 ## License
 


### PR DESCRIPTION
ITE-6 introduced the in-toto attestation framework. Since then, we've seen a number of attestation types be proposed and used such as SLSA provenance, runtime trace attestations, SCAI, and more. However, ITE-6 did not update in-toto layouts with mechanisms to verify the contents of new attestation types.

The latest draft of the ITE allows for verifying attribute claims at each step using lightweight DSLs built for such validations via `expectedAttributes` alongside the standard `expectedMaterials` and `expectedProducts`. It also adds similar support to current inspections. Finally, it adds a variation of a standard inspection that collects all claims pertaining to one or more subjects and applies specified constraints against those claims.