### PR TITLE
add use case section to ITE-9

### DIFF
--- a/ITE/9/README.adoc
+++ b/ITE/9/README.adoc
@@ -59,6 +59,10 @@ The new attestation definition SHOULD include the following fields.
 
 This section must discuss at a high level the reason for creating the new attestation type. Essentially, it describes the problems that can be solved using the new attestation.
 
+==== Use Cases
+
+This section must discuss the use cases that will be solved by this predicate and how the current predicate types (if any) do not solve this.
+
 ==== Prerequisites
 
 New attestation types may be very specific to a particular technology or specification, which must be detailed in the prerequisites section. The in-toto attestation framework is likely a necessary prerequisite for all attestation types, but it SHOULD be explicitly mentioned to err on the side of caution.

--- a/ITE/9/README.adoc
+++ b/ITE/9/README.adoc
@@ -61,7 +61,7 @@ This section must discuss at a high level the reason for creating the new attest
 
 ==== Use Cases
 
-This section must discuss the use cases that will be solved by this predicate and how the current predicate types (if any) do not solve this.
+This section must discuss at least one concrete use case that will be covered by this predicate and how the current predicate types (if any) do not solve this.
 
 ==== Prerequisites
 


### PR DESCRIPTION
Signed-off-by: pxp928 <parth.psu@gmail.com>

Based on the discussion in our last in-toto attestation maintainer meeting, new predicates needs to include a valid use case section to determine what it solves and how the current predicates (if any) don't solve this use case.  

cc @marcelamelara @TomHennen @adityasaky 