### PR TITLE
Update ITE-10: change step predicates and add selectors

### DIFF
--- a/ITE/10/README.adoc
+++ b/ITE/10/README.adoc
@@ -123,14 +123,20 @@ expected_predicate: expectedStepPredicate
 
 The `expected_inputs` and `expected_outputs` fields replace the original
 `expected_materials` and `expected_products` fields, respectively, to generalize
-theri semantics. This change maintains the core model of the original in-toto
-layout associating a single predicate with a single step (rather than a single
-command). It is also still true that if two attestations do not share the input
-and output artifacts, they must belong to different steps. The `expected_inputs`
-field retains the current semantics that all steps have inputs regardless of
-predicate type, so it applies to all predicates, informational and
-transformational, but does the name of the field containing the inputs must
-still be indicated within the `expected_predicate` information.
+their semantics. This change maintains the core model of the in-toto v1 layout
+associating a single predicate with a single step (rather than a single
+command). It is also still true that, `expected_inputs` and `expected_outputs`
+specify a list of artifact rules against which step inputs and outputs must be
+checked. Thus, if two attestations do not share the input and output artifacts,
+it is still true that they must belong to different steps.
+
+The `expected_inputs` field retains the current semantics that all steps have
+inputs regardless of predicate type, so it applies to all predicates,
+informational and transformational, but does the name of the field containing
+the inputs must still be indicated within the `expected_predicate` information.
+Of course, as informational predicates do not specify output artifacts, the
+`expected_outputs` field does not apply to them and may be omitted or left empty
+for the corresponding step.
 
 Each `expectedStepPredicate` object has the following schema.
 

--- a/ITE/10/README.adoc
+++ b/ITE/10/README.adoc
@@ -118,35 +118,37 @@ name: string
 command: list of strings
 expected_materials: list of artifact rules
 expected_products: list of artifact rules
-expected_predicates: list of expectedStepPredicates
+expected_predicate: expectedStepPredicate
 ```
 
 Each `expectedStepPredicate` object has the following schema.
 
 ```
 predicateType: string
+materials_selector: string
+products_selector: string
 functionaries: list of authorized functionary key IDs
 threshold: int
 ```
 
 The `predicateType` field contains the matching `TypeURI` of the predicate
-expected for the step. The original `pubkeys` field is updated to
+expected for the step. To support both transformational and informational
+predicates that may use different field names to record step materials and/or
+products, the `materials_selector` and `products_selector` fields to indicate
+the specific ITE-6 attestation field names verifiers should check for materials
+and products, respectively. The original `pubkeys` field is updated to
 `functionaries` to generalize signing semantics. Finally, `threshold` applies
 per predicate type rather than the step as a whole. Note that this schema
 supports the in-toto Attestation Framework while retaining all the capabilities
 of in-toto 1.0 layouts.
 
-This change maintains the core model of the original in-toto layout while
-allowing for multiple predicate types to be associated for a single step. Note
-that while this schema allows for multiple predicate types, the expectation is
-that they share the same materials and products--if two attestations do not
-share the input and output artifacts, they must belong to different steps. Of
-course, as informational predicates do not specify artifact products, the
-`expectedProducts` field does not apply to them. In a step with exclusively
-informational predicates, the `expectedProducts` field may be omitted or left
-empty. In a step with a mixture of transformational and informational
-predicates, the field only applies to the transformational predicates. The
-`expectedMaterials` field functions as it currently does, and applies to all
+This change maintains the core model of the original in-toto layout associating
+a single predicate with a single step (rather than a single command). It is
+also still true that if two attestations do not share the input and output
+artifacts, they must belong to different steps. Of course, as informational
+predicates do not specify artifact products, the `expectedProducts` field does
+not apply to them and may be omitted or left empty for the corresponding step.
+The `expectedMaterials` field functions as it currently does, and applies to all
 predicates, informational and transformational.
 
 === Supporting Sublayouts
@@ -158,23 +160,28 @@ verification workflow by presenting the sublayout file in place of the link
 expected for the corresponding step.
 
 The updated in-toto layout specified in this ITE is similar. The step is
-declared with one or more expected predicate types and when a layout is
-encountered, the verifier recursively verifies the sublayout, generating the
-expected predicates in the process. Note that this expects the verifier to be
-capable of generating distinct predicates--the in-toto v1.0 verifier was only
-aware of links and sublayout verification therefore generated an in-toto summary
-link. This is discussed further on in <<Custom Verifiers>>.
+declared with an expected predicate type and when a layout is encountered, the
+verifier recursively verifies the sublayout, generating the expected predicates
+in the process. Note that this expects the verifier to be capable of generating
+distinct predicates--the in-toto v1.0 verifier was only aware of links and
+sublayout verification therefore generated an in-toto summary link. This is
+discussed further on in <<Custom Verifiers>>.
 
 === Verifying Artifact Rules
 
-The verification workflow in the in-toto specification matches links to use by
-the name of the step and the key ID used to sign it. This part of the workflow
-is updated to support matching on predicate types as well. In addition,
+The verification workflow in the in-toto v1.0 specification matches links to
+use by the name of the step and the key ID used to sign it. This part of the
+workflow is updated to support matching on predicate types as well. In addition,
 artifact rules are updated to support
 link:https://github.com/in-toto/attestation/blob/main/spec/v1/resource_descriptor.md[ResourceDescriptor]
 defined in the in-toto Attestation Framework. The `name` field in a
-ResourceDescriptor object is used for pattern matching and the `digests` field
+ResourceDescriptor object is used for pattern matching and the `digest` field
 is used to verify equality of two artifacts.
+
+As in in-toto v.10, the `layoutEnvelope` and `layoutKeys` contain the signed
+layout and the signer's keys. The generalized `attestations` parameter is the
+set of in-toto attestations (with any predicate) to be checked against the
+layout. As before, `now` represents a current timestamp.
 
 ```go
 func Verify(layoutEnvelope, layoutKeys, attestations, now) {
@@ -221,7 +228,7 @@ As noted above, in-toto v1.0's verification workflow generates an in-toto
 summary link if verification succeeds. This is a powerful semantic that allows
 features like sublayouts (which enable delegating the supply chain definition
 for a step to authorized functionaries), and summarized verification (for
-environments with limited resources). With the introduction of in-toto
+environments with limited resources). With the introduction of the in-toto
 Attestation Framework, the verification workflow can be parametrized to support
 generating specific predicates as needed. For example, the default verifier can
 generate an in-toto link, another can generate SLSA Provenance, while for the

--- a/ITE/10/README.adoc
+++ b/ITE/10/README.adoc
@@ -116,40 +116,42 @@ This ITE proposes updating this schema to incorporate predicate types.
 ```
 name: string
 command: list of strings
-expected_materials: list of artifact rules
-expected_products: list of artifact rules
+expected_inputs: list of artifact rules
+expected_outputs: list of artifact rules
 expected_predicate: expectedStepPredicate
 ```
+
+The `expected_inputs` and `expected_outputs` fields replace the original
+`expected_materials` and `expected_products` fields, respectively, to generalize
+theri semantics. This change maintains the core model of the original in-toto
+layout associating a single predicate with a single step (rather than a single
+command). It is also still true that if two attestations do not share the input
+and output artifacts, they must belong to different steps. The `expected_inputs`
+field retains the current semantics that all steps have inputs regardless of
+predicate type, so it applies to all predicates, informational and
+transformational, but does the name of the field containing the inputs must
+still be indicated within the `expected_predicate` information.
 
 Each `expectedStepPredicate` object has the following schema.
 
 ```
-predicateType: string
-materials_selector: string
-products_selector: string
+predicate_type: string
+inputs_selector: string
+outputs_selector: string
 functionaries: list of authorized functionary key IDs
 threshold: int
 ```
 
-The `predicateType` field contains the matching `TypeURI` of the predicate
+The `predicate_type` field contains the matching `TypeURI` of the predicate
 expected for the step. To support both transformational and informational
-predicates that may use different field names to record step materials and/or
-products, the `materials_selector` and `products_selector` fields to indicate
-the specific ITE-6 attestation field names verifiers should check for materials
-and products, respectively. The original `pubkeys` field is updated to
+predicates that may use different field names to record step inputs and/or
+outputs, the `inputs_selector` and `outputs_selector` fields indicate the
+specific ITE-6 attestation field names verifiers should check for inputs and
+outputs, respectively. The original `pubkeys` field is updated to
 `functionaries` to generalize signing semantics. Finally, `threshold` applies
 per predicate type rather than the step as a whole. Note that this schema
-supports the in-toto Attestation Framework while retaining all the capabilities
-of in-toto 1.0 layouts.
-
-This change maintains the core model of the original in-toto layout associating
-a single predicate with a single step (rather than a single command). It is
-also still true that if two attestations do not share the input and output
-artifacts, they must belong to different steps. Of course, as informational
-predicates do not specify artifact products, the `expectedProducts` field does
-not apply to them and may be omitted or left empty for the corresponding step.
-The `expectedMaterials` field functions as it currently does, and applies to all
-predicates, informational and transformational.
+supports the in-toto Attestation Framework while retaining all the semantics and
+capabilities of in-toto 1.0 layouts.
 
 === Supporting Sublayouts
 
@@ -273,10 +275,10 @@ time communicated to their users, allowing them to transition their layouts.
 == Security
 
 This ITE does not significantly affect the security of in-toto layouts. It
-preserves all of the existing capabilities of in-toto layouts, meaning no
-existing properties are lost. It presents a consistent way to handle contextual
-predicates in artifact rules, meaning in-toto's powerful step-chaining
-properties can apply to the Attestation Framework.
+preserves all of the existing semantics and capabilities of in-toto layouts,
+meaning no existing properties are lost. It presents a consistent way to handle
+contextual predicates in artifact rules, meaning in-toto's powerful
+step-chaining properties can apply to the Attestation Framework.
 
 [[infrastructure-requirements]]
 == Infrastructure Requirements

--- a/ITE/10/README.adoc
+++ b/ITE/10/README.adoc
@@ -186,7 +186,7 @@ defined in the in-toto Attestation Framework. The `name` field in a
 ResourceDescriptor object is used for pattern matching and the `digest` field
 is used to verify equality of two artifacts.
 
-As in in-toto v.10, the `layoutEnvelope` and `layoutKeys` contain the signed
+As in in-toto v1.0, the `layoutEnvelope` and `layoutKeys` contain the signed
 layout and the signer's keys. The generalized `attestations` parameter is the
 set of in-toto attestations (with any predicate) to be checked against the
 layout, assuming it contains one attestation per step. As before, `now`

--- a/ITE/10/README.adoc
+++ b/ITE/10/README.adoc
@@ -204,7 +204,7 @@ func Verify(layoutEnvelope, layoutKeys, attestations, now) {
     }
 
     for _, step := range layout.Steps {
-        predicate := step.ExpectedPredicate {
+        predicate := step.ExpectedPredicate
         stepAttestation := attestationsForStepPredicate(predicate.Type, attestations)
         if predicate.Type == LAYOUT {
 	    sublayoutAttestations := resolveAttestations(stepAttestation)

--- a/ITE/10/README.adoc
+++ b/ITE/10/README.adoc
@@ -183,7 +183,8 @@ is used to verify equality of two artifacts.
 As in in-toto v.10, the `layoutEnvelope` and `layoutKeys` contain the signed
 layout and the signer's keys. The generalized `attestations` parameter is the
 set of in-toto attestations (with any predicate) to be checked against the
-layout. As before, `now` represents a current timestamp.
+layout, assuming it contains one attestation per step. As before, `now`
+represents a current timestamp.
 
 ```go
 func Verify(layoutEnvelope, layoutKeys, attestations, now) {
@@ -196,30 +197,27 @@ func Verify(layoutEnvelope, layoutKeys, attestations, now) {
         panic
     }
 
-
     for _, step := range layout.Steps {
-        stepAttestations := attestationsForStep(step.Name, attestations)
-        for _, predicate := range step.ExpectedPredicates {
-            predicateAttestations := attestationsForStepPredicate(predicate.Type, stepAttestations)
-            if predicate.Type == LAYOUT {
-                Verify(predicateAttestations[0], predicate.Functionaries, predicateAttestations[1:], now)
-            } else {
-                verifiedClaims := verifyAttestationSignatures(predicate.Functionaries, predicateAttestations)
-                if len(verifiedClaims) < threshold {
-                    panic
-                }
-                for _, attestation := range verifiedClaims {
-                    applyMaterialRules(step.ExpectedMaterials, attestation.Materials, attestations)
-                    applyProductRules(step.ExpectedProducts, attestation.Products, attestations)
-                }
+        predicate := step.ExpectedPredicate {
+        stepAttestation := attestationsForStepPredicate(predicate.Type, attestations)
+        if predicate.Type == LAYOUT {
+	    sublayoutAttestations := resolveAttestations(stepAttestation)
+            Verify(stepAttestation, predicate.Functionaries, sublayoutAttestations, now)
+        } else {
+            verifiedClaims := verifyAttestationSignatures(predicate.Functionaries, stepAttestation)
+            if len(verifiedClaims) < threshold {
+                panic
             }
+
+            applyInputRules(step.ExpectedInputs, stepAttestation.InputsSelector, attestations)
+            applyOutputRules(step.ExpectedOutputs, stepAttestation.ProductsSelector, attestations)
         }
     }
 
     for _, inspection := range layout.Inspections {
         inspectionAttestation := executeInspection(inspection.Command)
-        applyMaterialRules(inspection.ExpectedMaterials, inspectionAttestation.Materials, attestations)
-        applyProductRules(inspection.ExpectedProducts, inspectionAttestation.Products, attestations)
+        applyInputRules(inspection.ExpectedInputs, inspectionAttestation.InputsSelector, attestations)
+        applyOutputRules(inspection.ExpectedOutputs, inspectionAttestation.OutputsSelector, attestations)
     }
 }
 ```


### PR DESCRIPTION
This PR makes revisions to the current text of ITE-10 based on practical experiences and case studies verifying in-toto attestations:

* 1-1 predicate type-to-step mapping: This simplifies step definitions in layouts as well as attestation verifier implementations.
* Materials and products field selectors: Since the names of the fields for step materials and products are no longer consistent across predicate types, these selectors allow layout authors to indicate to verifiers where to extract this information from within attestations.

These changes were first proposed at [OpenSSF Community Day NA '25](https://sched.co/1zhne).